### PR TITLE
chore: open-source foundation — license, governance & community health

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Code owners — GitHub auto-requests a review from the matching owners on every PR.
+# Rules: last matching pattern WINS (so the global fallback is first); owners must have
+# write access (an owner without it is silently dropped); enforcement requires turning on
+# "Require review from Code Owners" in the main branch ruleset.
+# Docs: https://docs.github.com/articles/about-code-owners
+
+# Default for everything (including data/ and .github/): all maintainers.
+*           @marioalvial @viniarruda @pedrobullo
+
+# Electron overlay app.
+/app/       @marioalvial @viniarruda @pedrobullo
+
+# Memory reader — the highest-risk area (IL2CPP resolution, memory offsets, calibration).
+/reader/    @marioalvial

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,34 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.
+The full text is available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a
+harassment-free experience for everyone, regardless of age, body size, visible or invisible
+disability, ethnicity, sex characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive,
+and healthy community.
+
+## Our standards
+
+Be respectful, assume good faith, and keep discussion focused on the project. Give and accept
+constructive feedback gracefully, and prioritize what is best for the overall community.
+Behavior that the Contributor Covenant defines as unacceptable will not be tolerated — see the
+full text linked above for the complete list and the enforcement guidelines.
+
+## Enforcement
+
+Instances of abusive or otherwise unacceptable behavior may be reported privately to the
+maintainers. The preferred channel is GitHub's **Report a vulnerability** flow on the repository
+(it is private to maintainers), or a direct message to a maintainer on the community
+[Discord](https://discord.gg/eYqUkxu3). All complaints will be reviewed and investigated promptly
+and fairly. Maintainers are obligated to respect the privacy and security of the reporter.
+
+The enforcement guidelines (Correction → Warning → Temporary Ban → Permanent Ban) follow the
+Contributor Covenant 2.1 community-impact ladder linked above.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,157 @@
+# Contributing to TBH Meter
+
+Thanks for your interest! This guide covers local setup, the checks your PR must pass, and how
+releases work. By participating you agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Repository layout
+
+```
+app/      Electron overlay (TypeScript/React). Its OWN pnpm workspace — run pnpm from here.
+reader/   Python memory reader (pure ctypes + stdlib). Frozen to tbh-reader.exe by CI.
+data/     Committed game-data snapshot (JSON + sprites) the app bundles. Source of truth.
+scripts/  Maintainer tooling (refresh-game-data.mjs).
+.github/  CI + the release pipeline workflows.
+```
+
+Area-specific rules live in `app/CLAUDE.md` and `reader/CLAUDE.md`. **Before touching reader code,
+read `reader/docs/_index.md`** — the reader is the highest-risk part of the project (IL2CPP
+resolution, memory offsets, calibration) and the knowledge base there is the source of truth.
+
+## Prerequisites
+
+- **Node 22** and **pnpm** (`corepack enable` or install pnpm directly) — for the app.
+- **Python 3.12** — for the reader.
+- **Windows** to actually attach to the game. The app UI, lint, and tests run on macOS/Linux too;
+  only the live memory-reading path is Windows-only.
+
+## Working on the app
+
+```bash
+cd app
+pnpm install
+pnpm dev      # launch the overlay. On macOS this renders the UI only (no game attach) —
+              # feed fake artifacts into your ~/tbh-meter folder to exercise the watchers.
+pnpm dev:mock # same as `pnpm dev`, but runs against a mocked API with NO backend (MSW) —
+              # auth/upload/error-relay all complete locally; see src/mocks/.
+pnpm check    # eslint + tsc (both tsconfigs) — must pass
+pnpm test     # vitest — must pass
+```
+
+`pnpm dev`/`build`/`test` run `sync-data` first, which copies the `data/` snapshot into the app's
+(git-ignored) runtime dirs. **Never hand-edit `app/src/shared/data/` or
+`app/src/renderer/public/{sprites,heroes}/`** — they are regenerated. To change bundled game data,
+refresh the snapshot (below) instead.
+
+## Working on the reader
+
+```bash
+cd reader
+pip install ruff -r requirements-dev.txt
+ruff check .            # lint — must pass
+python -m pytest        # tests — must pass (platform-independent; they run anywhere)
+```
+
+The reader has **no runtime dependencies** (pure `ctypes` + stdlib). The release pipeline freezes it
+into `tbh-reader.exe` with PyInstaller, bundling `reader/config/` (offsets, level curve, and the
+calibration seed). Maintainer scripts for live calibration live in `reader/scripts/` and require
+Windows + the game running.
+
+## Refreshing game data after a patch (maintainers)
+
+When Task Bar Hero updates and the bundled metadata goes stale, regenerate the `data/` snapshot from
+a [Task Bar Hero Wiki](https://tbherohelper.com) checkout (which runs the datamine pipeline):
+
+```bash
+node scripts/refresh-game-data.mjs --wiki /path/to/tbh-wiki
+```
+
+That rewrites `data/{json,sprites,heroes}`. Commit the result. (A game patch usually also needs the
+reader re-calibrated — see `reader/CLAUDE.md` / the reader docs.)
+
+## Branching model
+
+Trunk-based — there is no `dev` or `prod` branch. `main` is the single long-lived branch and is
+always releasable.
+
+- **Branch off `main`** for every change (`fix/…`, `feat/…`); never commit to `main` directly.
+- **Open a PR.** CI (the app + reader gates and the gitleaks scan) and a maintainer review must pass
+  before it merges — that gate is what keeps `main` shippable.
+- **Merging to `main` does not ship anything to players** (see *How releases work*, below). It lands
+  the change and auto-stages a release *candidate* tag; nothing reaches users until a maintainer
+  ships, deliberately.
+- **Unfinished or risky work goes behind a flag/config**, not a long-lived branch, so it can land on
+  `main` without being switched on for users.
+
+"Production" is not a branch: it is whatever release is flagged **Latest** on this repository's
+[Releases](../../releases) — the feed the in-app updater follows. (A release branch would only make
+sense to maintain an *old* version line in parallel; auto-update means everyone moves forward
+together, so we don't keep one.)
+
+## Maintainers & governance
+
+Maintained by @marioalvial, @viniarruda, and @pedrobullo (see `.github/CODEOWNERS` for who reviews
+what). Governance is deliberately light for a small project: changes land by **maintainer consensus**
+through PR review, and when there's no clear consensus the **code owner of the affected area** has the
+final say for that area. New maintainers are invited by the current ones after a track record of solid
+contributions. Security issues follow [`SECURITY.md`](./SECURITY.md), conduct follows the
+[Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Commits & pull requests
+
+- **Use [Conventional Commits](https://www.conventionalcommits.org)** (`feat:`, `fix:`, `chore:`,
+  `feat!:`/`BREAKING CHANGE:`). They are **load-bearing**: the release pipeline computes the next
+  version from them, and the changelog is built from the subjects.
+- Keep PRs focused. Fill in the PR template, including how you tested.
+- CI (`.github/workflows/ci.yml`) runs the app and reader gates above on every PR. A
+  [gitleaks](https://github.com/gitleaks/gitleaks) secret scan also runs — **never commit secrets**.
+
+## How releases work (maintainers)
+
+Releases are driven by `tbh-meter-v*` git tags and are **decoupled from merging**: merging a PR to
+`main` never ships to players — you ship deliberately, when you decide. Installers and the
+auto-update feed are published as **GitHub Releases on this repository** — the same feed the in-app
+updater and the wiki's download button read.
+
+### What goes into the next release, and when
+
+- **What** — every meter commit (`app/`, `reader/`, `data/`) merged to `main` **since the last stable
+  `tbh-meter-v<x.y.z>` tag**. It is always visible: the **Create version tag** run prints
+  _"Meter commits since vX: N"_ and lists the pending changes in its run summary, and locally
+  `git log <last-stable-tag>..main -- app reader data` shows the same set. Those commit subjects
+  become the release changelog — so writing good Conventional Commit subjects _is_ writing the
+  changelog.
+- **When** — a deliberate maintainer decision; there is no automatic ship. Cut a release when enough
+  has accumulated to be worth it, or when a fix needs to reach players now. The pipeline keeps the
+  next version staged and ready, so you only choose the moment.
+- **Version** — computed from those commits (`feat` → minor, `fix` → patch, breaking → major; while
+  the major is `0`, both `feat` and breaking bump the minor).
+
+For planning _intent_ (what you'd like in a release vs. what is actually staged), optionally keep a
+GitHub **Milestone** per version — but the commit range above stays the source of truth for what
+actually ships.
+
+### The pipeline — three numbered workflows
+
+Tag-driven, in the Actions tab (the build only runs on demand):
+
+1. **Create version tag** (`meter-1-stage`) — automatic on push to `main` touching `app/`,
+   `reader/`, or `data/`. Computes the next RC version from the commits and pushes a marker tag. No
+   build.
+2. **Build test version** (`meter-2-build`) — manual. Builds a side-by-side RC installer and
+   publishes it as a **draft release** here for smoke-testing.
+3. **Release to players** (`meter-3-ship`) — manual. Rebuilds the chosen RC as the stable app,
+   flips it to *Latest*, tags the built commit, and announces it.
+
+`meter-build-core` is the internal Windows build shared by 2 and 3. Versioning is driven by
+`tbh-meter-v*` git tags (see `app/scripts/compute-version.mjs`); the `package.json` version is only a
+floor.
+
+### Required repository secrets (maintainers)
+
+| Secret | Used by | Purpose |
+|---|---|---|
+| `DISCORD_ANNOUNCE_WEBHOOK` | meter-3 | Posts the release announcement to Discord. |
+
+The default `GITHUB_TOKEN` covers everything else — publishing releases, tag pushes, and changelog
+reads — since the source, the pipeline, and the release artifacts now all live in this one
+repository. CI and the secret scan need no secrets.

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Adds a "Sponsor" button to the repository header.
+# Docs: https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+buy_me_a_coffee: viniarruda

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug report
+description: Something in the meter is broken or behaving unexpectedly.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting! For problems that look like a crash or "antivirus blocked it",
+        attaching `meter.log` (in your `tbh-meter` user-data folder) helps a lot.
+  - type: input
+    id: version
+    attributes:
+      label: Meter version
+      description: Shown in the app (Settings/About) or the installer filename, e.g. 0.34.0.
+      placeholder: "0.34.0"
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Windows version
+      description: e.g. Windows 11 23H2.
+      placeholder: "Windows 11"
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Which part?
+      options:
+        - Not sure
+        - App / overlay UI
+        - Reader (stats wrong, gold 0, stage "?", not attaching)
+        - Upload / leaderboard
+        - Auto-update
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What you expected vs. what you saw.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Launch the meter
+        2. Start a run ...
+        3. ...
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: Paste relevant lines from `meter.log` (and `updater.log` for update issues), or drag in a screenshot.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord community
+    url: https://discord.gg/eYqUkxu3
+    about: Questions, help, and chat about the meter and Task Bar Hero.
+  - name: Task Bar Hero Wiki
+    url: https://tbherohelper.com
+    about: The companion wiki, leaderboard, and run database.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: Suggest an improvement or a new capability for the meter.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: The use case or pain point. "I'm always trying to ..."
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What you'd like the meter to do.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you've thought about (optional).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+## Description
+
+<!-- What changed and WHY. One short paragraph. -->
+
+<!-- If this PR closes an issue, keep the next line; otherwise delete it. -->
+Closes #ISSUE
+
+## Key changes
+
+- <!-- change 1 -->
+- <!-- change 2 -->
+
+## Screenshots
+
+<!-- Required for any UI change to the overlay/list windows. Drag images in here. Delete this
+     section for non-UI PRs. -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would break existing behavior)
+- [ ] Refactor / chore / docs (no user-visible behavior change)
+
+## How was this tested?
+
+- [ ] `app/`: `pnpm check` and `pnpm test` pass
+- [ ] `reader/`: `ruff check .` and `pytest` pass
+- [ ] Manually verified in the running app (Windows for the reader path; macOS dev renders the UI only)
+
+## Checklist
+
+- [ ] Conventional commit subjects — they drive the computed release version and the changelog
+- [ ] Self-reviewed the diff
+- [ ] No hand-edits to generated/synced files (`app/src/shared/data/`, `app/src/renderer/public/{sprites,heroes}/`) — edit the `data/` snapshot via `scripts/refresh-game-data.mjs` instead
+- [ ] No secrets committed

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Report privately through GitHub's [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability):
+open the **Security** tab of this repository and click **Report a vulnerability**. That opens a
+private advisory only the maintainers can see.
+
+Please include:
+
+- What the issue is and the impact you expect.
+- Steps to reproduce (a proof of concept helps).
+- The affected component: the meter **app** (`app/`) or the **reader** (`reader/`).
+
+We aim to acknowledge a report within a few days and to keep you updated while we work on a fix.
+Please give us reasonable time to ship a fix before any public disclosure.
+
+## Scope
+
+In scope:
+
+- The Electron overlay app (`app/`).
+- The Python memory reader (`reader/`), shipped as `tbh-reader.exe`.
+- The release pipeline (`.github/workflows/`).
+
+Out of scope:
+
+- The Task Bar Hero game itself. This is an unaffiliated fan project; report game issues to the
+  game's developer.
+- The Task Bar Hero Wiki / leaderboard API (a separate project at tbherohelper.com). The meter only
+  *calls* its public HTTP endpoints — report API/website issues there.
+- Dependency advisories with no demonstrated exploit in this project.
+- Findings that require an already-compromised machine or physical access.
+
+## What the reader does (so you can assess risk)
+
+The reader attaches to the running game process and reads its memory (`ReadProcessMemory` on
+Windows) to compute per-run stats. It does **not** write to game memory, modify game files, or
+inject code — it is a read-only sensor. It is unsigned (see the README for the SmartScreen note),
+which is the most common false-positive reported by antivirus software.
+
+## How secrets are handled
+
+No credentials are committed to this repository. The app talks only to public endpoints
+(`api.tbherohelper.com`) and stores its own per-user auth token locally in the OS user-data
+directory. A [gitleaks](https://github.com/gitleaks/gitleaks) scan runs in CI on every pull request
+and push to keep the history secret-free (config: [`.gitleaks.toml`](../.gitleaks.toml)).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mad Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## What & why

First step of opening this repo as the open-source home of TBH Meter. Per the migration premise, **process & documentation come first; source code lands last** — this PR adds the legal + community baseline with **no source code** yet.

Everything here is code-independent. `app/`, `reader/`, `data/` paths are referenced ahead of time so the docs are ready when the code arrives.

## Included

- **`LICENSE`** — MIT
- **`.github/CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1
- **`.github/SECURITY.md`** — private vulnerability reporting + scope
- **`.github/CONTRIBUTING.md`** — local setup (app/reader), branching model, and "How releases work" — rewritten for the **same-repo model**: releases are published here via the default `GITHUB_TOKEN`, **no cross-repo PAT**
- **`.github/CODEOWNERS`** — per-area review routing
- **`.github/PULL_REQUEST_TEMPLATE.md`** + **`.github/ISSUE_TEMPLATE/`** (bug, feature, config)
- **`.github/FUNDING.yml`**

## Known follow-ups (next layers, not this PR)

- `SECURITY.md` links `.gitleaks.toml` → lands with the **CI layer**.
- `dependabot.yml` → deferred until `app/`/`reader/` manifests exist (would error on missing manifests now).
- `README.md` footer still says "artifacts only / built by private tbh-wiki CI" → updated when the code lands.

## Roadmap after this

1. **Repo config** — branch ruleset, labels, anti-force-push hooks, Discussions
2. **CI / test env** — `ci.yml` + `secret-scan.yml` + `.gitleaks.toml` (path-filtered, inert until code)
3. **Release pipeline** — `meter-1/2/3` + core, reworked for same-repo
4. **Code** — `app/ reader/ data/ scripts/` + README merge (last)