### PR TITLE
ci: app/reader CI gates + same-repo release pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+# Dependabot — opens PRs to keep dependencies (and the SHA-pinned actions) current and patched.
+# Security updates land regardless of this file; this configures the scheduled VERSION updates.
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # GitHub Actions — the pair to the SHA-pinned `uses:` from the workflow-hardening PR: Dependabot
+  # reads the `# vX.Y.Z` comment and bumps the pinned SHA + comment together, so pinning stays
+  # maintainable instead of rotting. Only touches .github/, so it never mints a meter release.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "ci(deps)"
+    labels: ["dependencies"]
+
+  # --- Uncomment when the source lands ---------------------------------------------------------
+  # app/ and reader/ don't exist yet, so Dependabot would report "manifest not found". Restore
+  # these two blocks in the PR that brings the code.
+  #
+  # # The Electron app (pnpm is read under the "npm" ecosystem). Minor/patch are grouped into one
+  # # weekly PR; majors come as individual PRs so a breaking Electron/React bump gets focused review.
+  # - package-ecosystem: "npm"
+  #   directory: "/app"
+  #   schedule:
+  #     interval: "weekly"
+  #   groups:
+  #     app:
+  #       patterns: ["*"]
+  #       update-types: ["minor", "patch"]
+  #   open-pull-requests-limit: 5
+  #   commit-message:
+  #     prefix: "chore(deps)"
+  #     prefix-development: "chore(deps-dev)"
+  #   labels: ["dependencies"]
+  #
+  # # The reader's dev tooling (pytest, etc.) — the shipped reader is pure stdlib, so these are
+  # # dev-only. Monthly: they move slowly, and any reader/ change stages a (harmless, unshipped) RC.
+  # - package-ecosystem: "pip"
+  #   directory: "/reader"
+  #   schedule:
+  #     interval: "monthly"
+  #   groups:
+  #     reader-dev:
+  #       patterns: ["*"]
+  #   commit-message:
+  #     prefix: "chore(deps-dev)"
+  #   labels: ["dependencies"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # Continuous integration — runs on every push to main and every pull request.
 # Free unlimited standard runners on public repos. Two independent jobs mirror the two pieces
 # of the meter (the Electron app and the Python reader) and the local verify commands.
-name: CI
+name: Check · CI
 
 on:
   push:
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   app:
-    name: app · lint + types + tests
+    name: app
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
@@ -63,7 +63,7 @@ jobs:
         run: pnpm test
 
   reader:
-    name: reader · ruff + pytest
+    name: reader
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
-# Continuous integration — runs on every push to main and every pull request.
-# Free unlimited standard runners on public repos. Two independent jobs mirror the two pieces
-# of the meter (the Electron app and the Python reader) and the local verify commands.
+# Continuous integration — runs on PRs and pushes to main that touch the source.
+# Free unlimited standard runners on public repos, so the app's lint/types, unit, and integration
+# suites run as SEPARATE parallel jobs (plus the Python reader) instead of one serial job.
 name: Test · CI
 
 on:
@@ -26,8 +26,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  app:
-    name: app
+  app-lint:
+    name: app · lint + types
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:
@@ -37,30 +37,75 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           package_json_file: app/package.json
-
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: app/pnpm-lock.yaml
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      # tsc imports src/shared/data/*.json (git-ignored, regenerated). Populate them from the
-      # committed snapshot before `check`; `test` re-syncs via its pretest hook (harmless).
+      # tsc imports src/shared/data/*.json (git-ignored, regenerated) — populate from the snapshot.
       - name: Sync game data from the committed snapshot
         run: pnpm sync-data
-
       - name: Lint + typecheck (eslint + tsc)
         run: pnpm check
 
+  app-unit:
+    name: app · unit
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: app
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          package_json_file: app/package.json
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: app/pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Sync game data from the committed snapshot
+        run: pnpm sync-data
+      # Everything EXCEPT *.integration.test.ts (those run in the integration job, in parallel).
       - name: Unit tests (vitest)
-        run: pnpm test
+        run: pnpm exec vitest run --exclude '**/*.integration.test.ts'
+
+  app-integration:
+    name: app · integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: app
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          package_json_file: app/package.json
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: app/pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Sync game data from the committed snapshot
+        run: pnpm sync-data
+      # Only the *.integration.test.ts files (module-wiring tests; fixtures/MSW, no real game).
+      - name: Integration tests (vitest)
+        run: pnpm exec vitest run integration.test
 
   reader:
     name: reader
@@ -73,19 +118,14 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
-
-      # The reader itself is zero-dependency (pure ctypes + stdlib); only the lint/test tooling
-      # is installed. The tests are platform-independent (they never touch Windows-only APIs at
-      # import time), so they run on the free Linux runner.
+      # The reader is zero-dependency (pure ctypes + stdlib); only the lint/test tooling is
+      # installed. The tests are platform-independent, so they run on the free Linux runner.
       - name: Install lint + test tooling
         run: pip install ruff -r requirements-dev.txt
-
       - name: Lint (ruff)
         run: ruff check .
-
       - name: Tests (pytest)
         run: python -m pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+# Continuous integration — runs on every push to main and every pull request.
+# Free unlimited standard runners on public repos. Two independent jobs mirror the two pieces
+# of the meter (the Electron app and the Python reader) and the local verify commands.
+name: CI
+
+on:
+  push:
+    branches: [main]
+    # Scoped to the source tree. Until app/ and reader/ land, these paths don't exist, so CI
+    # stays inert — it never runs (and never reddens main when this file itself merges).
+    paths:
+      - "app/**"
+      - "reader/**"
+      - "data/**"
+  pull_request:
+    paths:
+      - "app/**"
+      - "reader/**"
+      - "data/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  app:
+    name: app · lint + types + tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: app
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          package_json_file: app/package.json
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: app/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # tsc imports src/shared/data/*.json (git-ignored, regenerated). Populate them from the
+      # committed snapshot before `check`; `test` re-syncs via its pretest hook (harmless).
+      - name: Sync game data from the committed snapshot
+        run: pnpm sync-data
+
+      - name: Lint + typecheck (eslint + tsc)
+        run: pnpm check
+
+      - name: Unit tests (vitest)
+        run: pnpm test
+
+  reader:
+    name: reader · ruff + pytest
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: reader
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      # The reader itself is zero-dependency (pure ctypes + stdlib); only the lint/test tooling
+      # is installed. The tests are platform-independent (they never touch Windows-only APIs at
+      # import time), so they run on the free Linux runner.
+      - name: Install lint + test tooling
+        run: pip install ruff -r requirements-dev.txt
+
+      - name: Lint (ruff)
+        run: ruff check .
+
+      - name: Tests (pytest)
+        run: python -m pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # Continuous integration — runs on every push to main and every pull request.
 # Free unlimited standard runners on public repos. Two independent jobs mirror the two pieces
 # of the meter (the Electron app and the Python reader) and the local verify commands.
-name: Check · CI
+name: Test · CI
 
 on:
   push:

--- a/.github/workflows/meter-1-stage.yml
+++ b/.github/workflows/meter-1-stage.yml
@@ -1,0 +1,166 @@
+# TBH Meter / 1. Create version tag (AUTOMATIC — you never click this).
+#
+# Two cheap, build-free housekeeping jobs:
+#
+#  • stage  (on push to main touching the meter): computes the next RC version from
+#    conventional commits and pushes a marker tag `tbh-meter-v<ver>-rc.<N>` at the commit.
+#    NO build — the Windows build happens on demand in Meter 2 / Meter 3. If NOTHING under
+#    the meter build inputs (app/, reader/, data/) changed since the last release,
+#    compute-version refuses (exit 2) and this is a green no-op ("nothing staged") — that is the
+#    P1 guard: a version exists only when the meter actually changed. (Re-calibrating the reader
+#    after a game patch writes reader/config/calib_seed.json, which IS a meter change, so it
+#    stages normally.)
+#
+#  • clean-pr-slot  (on ANY PR close): deletes that PR's throwaway draft build
+#    (`tbh-meter-pr-<N>`) on the releases repo, so a merged/closed PR never leaves a stale
+#    installer behind. No paths filter on purpose — it must fire even for a PR that never
+#    touched the meter but got a test build.
+#
+# `-rc.N` tags never become the version base (only clean X.Y.Z tags do — compute-version.mjs),
+# so every RC keeps targeting the same stable version until Meter 3 ships it. Re-runs are
+# idempotent: a commit already staged reuses its tag instead of minting a new rc number.
+name: TBH Meter / 1. Create version tag (auto)
+
+run-name: "${{ github.event_name == 'pull_request' && format('Clean up PR #{0} test build', github.event.pull_request.number) || '' }}"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "app/**"
+      - "reader/**"
+      - "data/**"
+      # NOTE: the pipeline workflow files are deliberately NOT listed here yet. Until the source
+      # (app/, reader/) lands, a self-referencing path would fire `stage` on a pipeline-only edit
+      # and fail (no compute-version.mjs). Re-add them in the PR that brings the code.
+  pull_request:
+    types: [closed]
+
+concurrency:
+  # Push-stages serialize together; PR-close cleanups serialize per-PR. cancel-in-progress:false
+  # so a running stage is never aborted. (GitHub keeps one pending run per group, so a 3-push
+  # burst may supersede the middle PENDING run — that is fine: the surviving run stages the
+  # newest commit, which covers the whole range, and rc numbers are recomputed from the tags.)
+  group: meter-stage-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'main' }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  stage:
+    name: Compute + push the next RC tag
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    # Only this job needs the token to push the version tag.
+    permissions:
+      contents: write
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Full history + tags: compute-version reads tbh-meter-v* tags and commits since
+          # the latest stable one (a shallow clone would see neither).
+          fetch-depth: 0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Compute + push RC tag (refuses when the meter did not change)
+        id: rc
+        shell: bash
+        run: |
+          SCRIPT=app/scripts/compute-version.mjs
+
+          # Idempotent: if this commit already carries an rc tag, reuse it (don't mint a new N).
+          EXISTING=$(git tag --points-at "$GITHUB_SHA" --list 'tbh-meter-v*-rc.*' | head -n1)
+          if [ -n "$EXISTING" ]; then
+            VERSION="${EXISTING#tbh-meter-v}"
+            echo "::notice::Commit already staged as $EXISTING — reusing (no new tag)."
+          else
+            # P1 guard: compute-version exits 2 with zero meter commits since the base tag.
+            set +e
+            VERSION=$(node "$SCRIPT" --prerelease rc 2>stage-err.log)
+            CODE=$?
+            set -e
+            cat stage-err.log >&2
+            if [ "$CODE" -eq 2 ]; then
+              echo "::notice::No meter changes since the last release — nothing staged."
+              {
+                echo "## 🟢 Nothing to stage"
+                echo
+                echo "No commits under the meter (\`app/\`, \`reader/\`, \`data/\`) since the last release tag, so no RC was minted."
+                echo "This is correct, not an error — a version exists only when the meter changes."
+              } >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            if [ "$CODE" -ne 0 ]; then
+              echo "::error::compute-version failed (exit $CODE)"; exit "$CODE"
+            fi
+            TAG="tbh-meter-v$VERSION"
+            # Lightweight tag; checkout@v4 persists GITHUB_TOKEN so the push is authenticated.
+            # A token-pushed tag does NOT re-trigger any workflow (push trigger is branch-only).
+            git tag "$TAG" "$GITHUB_SHA"
+            git push origin "refs/tags/$TAG"
+            echo "::notice::Staged $TAG"
+          fi
+
+          TAG="tbh-meter-v$VERSION"
+          ACTIONS="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions"
+          LAST_STABLE=$(git -c versionsort.suffix=-rc tag -l 'tbh-meter-v*' --sort=-v:refname \
+            | grep -E '^tbh-meter-v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)
+          RANGE="${LAST_STABLE:+$LAST_STABLE..}HEAD"
+          COUNT=$(git log "$RANGE" --no-merges --oneline -- app reader data | wc -l | tr -d ' ')
+          CHANGES=$(git log "$RANGE" --no-merges --pretty='- %s' -- app reader data | head -n 50)
+          {
+            echo "## 🏷️ Release candidate staged"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| **Version** | \`$VERSION\` |"
+            echo "| **Tag** | \`$TAG\` |"
+            echo "| **Commit** | \`${GITHUB_SHA:0:7}\` |"
+            echo "| **Meter commits since ${LAST_STABLE:-(first release)}** | $COUNT |"
+            echo
+            if [ -n "$CHANGES" ]; then
+              echo "<details><summary>Changes pending in this RC</summary>"
+              echo
+              echo "$CHANGES"
+              echo
+              echo "</details>"
+              echo
+            fi
+            echo "### Next steps"
+            echo "1. **[TBH Meter / 2. Build test version to download]($ACTIONS/workflows/meter-2-build.yml)** — no input needed (builds this newest RC)."
+            echo "2. Install & smoke-test it on Windows."
+            echo "3. **[TBH Meter / 3. Release to players]($ACTIONS/workflows/meter-3-ship.yml)** — no input needed (ships this newest RC)."
+            echo
+            echo "Builds land on [tbh-meter-releases](https://github.com/mad-labs-org/tbh-meter-releases/releases)."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  clean-pr-slot:
+    name: Delete the closed PR's test build
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    # Same-repo: drafts live here now, so the default token deletes them (no cross-repo PAT).
+    permissions:
+      contents: write
+    timeout-minutes: 10
+    steps:
+      - name: Delete draft slot tbh-meter-pr-<N> (if any)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR="${{ github.event.pull_request.number }}"
+          RELEASES_REPO="$GITHUB_REPOSITORY"
+          TAG="tbh-meter-pr-$PR"
+          # Drafts aren't returned by get-release-by-tag, so find the id via the list endpoint.
+          ID=$(gh api "repos/$RELEASES_REPO/releases" --paginate \
+            --jq "[.[] | select(.tag_name==\"$TAG\" and .draft==true)] | .[0].id // empty")
+          if [ -n "$ID" ]; then
+            gh api -X DELETE "repos/$RELEASES_REPO/releases/$ID" && echo "Deleted test build $TAG (id $ID)."
+          else
+            echo "No test build for PR #$PR — nothing to clean."
+          fi

--- a/.github/workflows/meter-1-stage.yml
+++ b/.github/workflows/meter-1-stage.yml
@@ -19,7 +19,7 @@
 # `-rc.N` tags never become the version base (only clean X.Y.Z tags do — compute-version.mjs),
 # so every RC keeps targeting the same stable version until Meter 3 ships it. Re-runs are
 # idempotent: a commit already staged reuses its tag instead of minting a new rc number.
-name: TBH Meter / 1. Create version tag (auto)
+name: Release · 1 · version tag
 
 run-name: "${{ github.event_name == 'pull_request' && format('Clean up PR #{0} test build', github.event.pull_request.number) || '' }}"
 

--- a/.github/workflows/meter-2-build.yml
+++ b/.github/workflows/meter-2-build.yml
@@ -16,7 +16,7 @@
 #
 # Each target owns exactly ONE draft slot (its tag name), replaced on every rebuild — so the
 # releases list stays an honest dashboard of what's live, never a pile of duplicates.
-name: TBH Meter / 2. Build test version to download
+name: Release · 2 · build test version
 
 run-name: "Build · ${{ inputs.pr != '' && format('PR #{0}', inputs.pr) || (inputs.candidate != '' && inputs.candidate || 'newest staged RC') }} — ${{ github.actor }}"
 

--- a/.github/workflows/meter-2-build.yml
+++ b/.github/workflows/meter-2-build.yml
@@ -1,0 +1,269 @@
+# TBH Meter / 2. Build test version to download — a Windows installer you can install and
+# smoke-test, that NEVER reaches players. MANUAL.
+#
+# It builds the side-by-side `rc` variant (own appId/folder, data in ~/tbh-meter-rc, auto-update
+# OFF) and publishes it as a DRAFT on the public releases repo — drafts are invisible to
+# anonymous users AND to electron-updater's /releases/latest, so a test build can never leak.
+# Maintainers download it while logged in.
+#
+# Two things you can build (the common case needs NO input):
+#   • blank          → the newest staged RC (the one Meter 1 just minted). The normal flow.
+#   • candidate=…    → a specific staged RC, e.g. 0.31.0-rc.2.
+#   • pr=342         → a THROWAWAY build of that PR's head, BEFORE merging. Version is
+#                      0.0.0-pr.342.<run> (honest: obviously not a real release; the PR number
+#                      gives it its own draft slot so two PRs can never collide), and the
+#                      download link is posted as a comment on the PR. Wins over `candidate`.
+#
+# Each target owns exactly ONE draft slot (its tag name), replaced on every rebuild — so the
+# releases list stays an honest dashboard of what's live, never a pile of duplicates.
+name: TBH Meter / 2. Build test version to download
+
+run-name: "Build · ${{ inputs.pr != '' && format('PR #{0}', inputs.pr) || (inputs.candidate != '' && inputs.candidate || 'newest staged RC') }} — ${{ github.actor }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate:
+        description: "Staged RC to build, e.g. 0.31.0-rc.2. Blank = the newest staged RC."
+        required: false
+        type: string
+      pr:
+        description: "PR number for a throwaway pre-merge build, e.g. 342. Wins over 'candidate'; the link is posted on the PR."
+        required: false
+        type: string
+
+concurrency:
+  # One build per target; different targets run in parallel, the same target serializes.
+  # cancel-in-progress:false so a re-run never aborts a draft mid-publish.
+  group: meter-build-${{ inputs.pr != '' && format('pr-{0}', inputs.pr) || (inputs.candidate != '' && inputs.candidate || 'newest-rc') }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    name: Resolve what to build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read # gh pr view
+    timeout-minutes: 10
+    outputs:
+      kind: ${{ steps.r.outputs.kind }}
+      sha: ${{ steps.r.outputs.sha }}
+      version: ${{ steps.r.outputs.version }}
+      slot_tag: ${{ steps.r.outputs.slot_tag }}
+      pr: ${{ steps.r.outputs.pr }}
+      branch: ${{ steps.r.outputs.branch }}
+      version_matrix: ${{ steps.r.outputs.version_matrix }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Resolve target → (kind, sha, version, slot)
+        id: r
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # gh pr view, against THIS repo
+          # Inputs via env (not direct ${{ }} interpolation into bash) — robust to odd quoting.
+          PR_INPUT: ${{ inputs.pr }}
+          CAND_INPUT: ${{ inputs.candidate }}
+        run: |
+          PR="$PR_INPUT"
+          CAND="$CAND_INPUT"
+          PR="${PR#\#}" # tolerate "#342"
+
+          if [ -n "$PR" ] && [ -n "$CAND" ]; then
+            echo "::error::Pass EITHER a PR number OR a candidate RC, not both."; exit 1
+          fi
+
+          if [ -n "$PR" ]; then
+            # --- Throwaway PR build (pre-merge) — gh's built-in --jq, no node needed ---
+            SHA=$(gh pr view "$PR" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq '.headRefOid' 2>/dev/null || true)
+            BRANCH=$(gh pr view "$PR" --repo "$GITHUB_REPOSITORY" --json headRefName --jq '.headRefName' 2>/dev/null || true)
+            if [ -z "$SHA" ]; then echo "::error::PR #$PR not found (or no head commit)."; exit 1; fi
+            VERSION="0.0.0-pr.$PR.${{ github.run_number }}"
+            SLOT="tbh-meter-pr-$PR"
+            KIND="pr"
+          else
+            # --- A staged RC tag ---
+            git fetch --tags -q
+            if [ -z "$CAND" ]; then
+              # Newest staged RC = highest rc-version tag (versionsort, rc-aware).
+              TAG=$(git -c versionsort.suffix=-rc tag -l 'tbh-meter-v*-rc.*' --sort=-v:refname | head -n1)
+              if [ -z "$TAG" ]; then
+                echo "::error::No staged RC found. Merge meter work (Meter 1 stages one) or pass a PR number."; exit 1
+              fi
+            else
+              TAG="tbh-meter-v${CAND#tbh-meter-v}"
+            fi
+            if ! git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+              echo "::error::Tag $TAG does not exist."; exit 1
+            fi
+            SHA=$(git rev-parse "$TAG^{commit}")
+            VERSION="${TAG#tbh-meter-v}"
+            SLOT="$TAG"
+            BRANCH=""
+            KIND="rc"
+          fi
+
+          echo "::notice::Building $VERSION ($KIND) from ${SHA:0:7}"
+          {
+            echo "kind=$KIND"
+            echo "sha=$SHA"
+            echo "version=$VERSION"
+            echo "slot_tag=$SLOT"
+            echo "pr=$PR"
+            echo "branch=$BRANCH"
+            echo "version_matrix=[\"$VERSION\"]"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build
+    needs: resolve
+    permissions:
+      contents: read
+    # The matrix value renders the COMPUTED version in the job name (build (0.31.0-rc.2)) —
+    # the only platform way to surface it in the Actions sidebar.
+    strategy:
+      matrix:
+        version: ${{ fromJSON(needs.resolve.outputs.version_matrix) }}
+    uses: ./.github/workflows/meter-build-core.yml
+    with:
+      ref: ${{ needs.resolve.outputs.sha }}
+      version: ${{ matrix.version }}
+      variant: rc
+
+  publish:
+    name: Publish draft
+    needs: [resolve, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # publishes the draft release in this repo
+      pull-requests: write # sticky PR comment with the download link
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: tbh-meter-rc-windows
+          path: dist
+
+      - name: Publish the draft (+ PR comment)
+        id: pub
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # publishes the draft release in this repo
+          NOTES_TOKEN: ${{ secrets.GITHUB_TOKEN }} # reads THIS repo (changelog) + PR comment
+          KIND: ${{ needs.resolve.outputs.kind }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+          SLOT: ${{ needs.resolve.outputs.slot_tag }}
+          PR: ${{ needs.resolve.outputs.pr }}
+          BRANCH: ${{ needs.resolve.outputs.branch }}
+          SHA: ${{ needs.resolve.outputs.sha }}
+        run: |
+          RELEASES_REPO="$GITHUB_REPOSITORY"
+          INSTALLER=$(basename dist/*.exe)
+
+          if [ "$KIND" = "pr" ]; then
+            TITLE="tbh-meter PR #$PR · build ${{ github.run_number }}"
+            {
+              echo "> 🧪 **Throwaway pre-merge test build** of PR #$PR (\`$BRANCH\` @ \`${SHA:0:7}\`)."
+              echo "> Side-by-side \`tbh-meter-rc\` build: own folder, data in \`~/tbh-meter-rc\`, **no** auto-update."
+              echo "> Not promotable — ship the real thing by merging, then Meter 2 → Meter 3."
+            } > release-notes.md
+          else
+            LAST_STABLE=$(git -c versionsort.suffix=-rc tag -l 'tbh-meter-v*' --sort=-v:refname \
+              | grep -E '^tbh-meter-v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)
+            RANGE="${LAST_STABLE:+$LAST_STABLE..}$SHA"
+            CHANGES=$(git log "$RANGE" --no-merges --pretty='- %s' -- app reader data | head -n 80)
+            TITLE="tbh-meter v$VERSION (RC)"
+            {
+              echo "> ⚠️ **Release candidate — for testing only.** Side-by-side \`tbh-meter-rc\` build:"
+              echo "> own folder, data in \`~/tbh-meter-rc\`, **no** auto-update. Your real install is untouched."
+              echo
+              if [ -n "$CHANGES" ]; then
+                echo "## Changes since ${LAST_STABLE:-the beginning}"; echo; echo "$CHANGES"; echo
+              fi
+            } > release-notes.md
+          fi
+          {
+            echo "## Download"
+            echo
+            echo "Grab **\`$INSTALLER\`** and run it."
+            echo
+            echo "## \"Windows protected your PC\" warning"
+            echo
+            echo "These builds are **not code-signed**, so SmartScreen shows a blue warning the first"
+            echo "time you run them. Click **More info → Run anyway**. If your antivirus quarantines"
+            echo "**tbh-reader.exe**, allow/restore it (bundled Python reader)."
+          } >> release-notes.md
+
+          # One mutable draft slot per target: remove any prior draft for this tag (the by-tag
+          # API can't see drafts, so list+filter), then recreate with the fresh installer.
+          DRAFT_ID=$(gh api "repos/$RELEASES_REPO/releases" --paginate \
+            --jq "[.[] | select(.tag_name==\"$SLOT\" and .draft==true)] | .[0].id // empty")
+          if [ -n "$DRAFT_ID" ]; then
+            gh api -X DELETE "repos/$RELEASES_REPO/releases/$DRAFT_ID"
+            echo "Replaced prior draft for $SLOT (id $DRAFT_ID)."
+          fi
+          URL=$(gh release create "$SLOT" dist/*.exe \
+            --repo "$RELEASES_REPO" --draft --title "$TITLE" --notes-file release-notes.md)
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "Published draft: $URL"
+
+          # PR mode: post/update a sticky comment with the link, where the dev is already looking.
+          if [ "$KIND" = "pr" ]; then
+            BODY=$(printf '%s\n' \
+              "🧪 **Test build ready** — \`$INSTALLER\`" \
+              "" \
+              "[**Download the installer**]($URL) (log in with access to the releases repo)." \
+              "Installs side-by-side as \`tbh-meter-rc\` — own folder, data in \`~/tbh-meter-rc\`, no auto-update. Your real install is untouched." \
+              "" \
+              "_build ${{ github.run_number }} · \`$BRANCH\` @ \`${SHA:0:7}\` · re-run Meter 2 for this PR to refresh._")
+            GH_TOKEN="$NOTES_TOKEN" gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --edit-last --body "$BODY" 2>/dev/null \
+              || GH_TOKEN="$NOTES_TOKEN" gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --body "$BODY"
+
+            # Race guard: if the PR already closed during this build, Meter 1's PR-close cleanup
+            # may have run before this draft existed — delete it now so no stale slot is orphaned.
+            STATE=$(GH_TOKEN="$NOTES_TOKEN" gh pr view "$PR" --repo "$GITHUB_REPOSITORY" --json state --jq '.state' 2>/dev/null || true)
+            if [ "$STATE" = "MERGED" ] || [ "$STATE" = "CLOSED" ]; then
+              DID=$(gh api "repos/$RELEASES_REPO/releases" --paginate \
+                --jq "[.[] | select(.tag_name==\"$SLOT\" and .draft==true)] | .[0].id // empty")
+              if [ -n "$DID" ]; then
+                gh api -X DELETE "repos/$RELEASES_REPO/releases/$DID" && echo "PR #$PR already $STATE — removed its now-orphan draft."
+              fi
+            fi
+          fi
+
+      - name: Job summary
+        if: always()
+        shell: bash
+        env:
+          URL: ${{ steps.pub.outputs.url }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+          SHA: ${{ needs.resolve.outputs.sha }}
+        run: |
+          {
+            echo "## 🧪 Test version built"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| **Version** | \`$VERSION\` |"
+            echo "| **From commit** | \`${SHA:0:7}\` |"
+            echo
+            if [ -n "$URL" ]; then
+              echo "### ➡️ [Open the draft & download the installer]($URL)"
+              echo
+              echo "Side-by-side \`tbh-meter-rc\` (own folder, \`~/tbh-meter-rc\`, no auto-update)."
+              echo "When it checks out, run **TBH Meter / 3. Release to players** to ship it."
+            else
+              echo "⚠️ Build ran but no draft URL — check the Publish step logs."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/meter-3-ship.yml
+++ b/.github/workflows/meter-3-ship.yml
@@ -17,7 +17,7 @@
 # Continuity: the clean `tbh-meter-v<ver>` tag is pushed to THIS repo at the BUILT commit, so
 # compute-version's base advances. Skipped/abandoned RC tags stay inert (only clean X.Y.Z tags
 # are ever the base), and their drafts are swept here. No tag is ever force-pushed.
-name: TBH Meter / 3. Release to players
+name: Release · 3 · ship to players
 
 run-name: "Release · ${{ inputs.direct_from_main && 'main → stable (direct)' || (inputs.candidate != '' && inputs.candidate || 'newest staged RC') }} — ${{ github.actor }}"
 

--- a/.github/workflows/meter-3-ship.yml
+++ b/.github/workflows/meter-3-ship.yml
@@ -1,0 +1,394 @@
+# TBH Meter / 3. Release to players — build the STABLE app and publish it as Latest, so
+# installed apps self-update. MANUAL.
+#
+# Two ways to ship (the common case needs NO input):
+#   • blank            → promote the newest staged RC (the one you just tested). The normal flow.
+#   • candidate=…      → promote a specific staged RC, e.g. 0.31.0-rc.2.
+#   • direct_from_main → SKIP the RC: version, build and ship main's CURRENT code straight to
+#                        players. Use when a fix is obvious enough to skip a test build. Refused
+#                        unless main actually changed since the last release (tick allow_empty to
+#                        force a rebuild — e.g. a build-only change).
+#
+# Why it BUILDS (not a flag-flip): the RC you tested is a side-by-side VARIANT (different
+# appId/data dir, auto-update OFF) — a different artifact from what users run. So it re-builds
+# the STABLE variant from the EXACT commit the RC points at (frozen lockfile → "ship == tested
+# commit"); only the trivial variant config differs. direct_from_main builds main's HEAD.
+#
+# Continuity: the clean `tbh-meter-v<ver>` tag is pushed to THIS repo at the BUILT commit, so
+# compute-version's base advances. Skipped/abandoned RC tags stay inert (only clean X.Y.Z tags
+# are ever the base), and their drafts are swept here. No tag is ever force-pushed.
+name: TBH Meter / 3. Release to players
+
+run-name: "Release · ${{ inputs.direct_from_main && 'main → stable (direct)' || (inputs.candidate != '' && inputs.candidate || 'newest staged RC') }} — ${{ github.actor }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate:
+        description: "RC to ship, e.g. 0.31.0-rc.2. Blank = the newest staged RC."
+        required: false
+        type: string
+      direct_from_main:
+        description: "Skip the RC: build & ship main's current code straight to players."
+        required: false
+        type: boolean
+        default: false
+      allow_empty:
+        description: "direct_from_main only — ship even with no meter changes since the last release (forced rebuild)."
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  # All ships serialize globally — never two Latest flips at once. Never cancel one in flight.
+  group: meter-ship-stable
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    name: Resolve + guard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 10
+    outputs:
+      sha: ${{ steps.r.outputs.sha }}
+      version: ${{ steps.r.outputs.version }}
+      stable_tag: ${{ steps.r.outputs.stable_tag }}
+      rc_tag: ${{ steps.r.outputs.rc_tag }}
+      mode: ${{ steps.r.outputs.mode }}
+      version_matrix: ${{ steps.r.outputs.version_matrix }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Resolve target + guard against empty / downgrade / duplicate
+        id: r
+        shell: bash
+        env:
+          # Inputs via env (not direct ${{ }} interpolation into bash) — robust to odd quoting.
+          DIRECT_INPUT: ${{ inputs.direct_from_main }}
+          CAND_INPUT: ${{ inputs.candidate }}
+          ALLOW_INPUT: ${{ inputs.allow_empty }}
+        run: |
+          DIRECT="$DIRECT_INPUT"
+          CAND="$CAND_INPUT"
+          ALLOW="$ALLOW_INPUT"
+          SCRIPT=app/scripts/compute-version.mjs
+
+          if [ "$DIRECT" = "true" ] && [ -n "$CAND" ]; then
+            echo "::error::Pass EITHER a candidate RC OR direct_from_main, not both."; exit 1
+          fi
+
+          if [ "$DIRECT" = "true" ]; then
+            # Ship main's current HEAD, no RC. Resolve main explicitly (FETCH_HEAD), so it works
+            # no matter which ref the workflow was dispatched from — never ships an unmerged branch.
+            git fetch --tags origin main -q
+            git -c advice.detachedHead=false checkout -q FETCH_HEAD
+            SHA=$(git rev-parse HEAD)
+            FLAGS=(); [ "$ALLOW" = "true" ] && FLAGS+=(--allow-empty)
+            set +e
+            VERSION=$(node "$SCRIPT" "${FLAGS[@]}" 2>ship-err.log)  # bare stdout = the version
+            CODE=$?
+            set -e
+            cat ship-err.log >&2
+            if [ "$CODE" -eq 2 ]; then
+              echo "::error::No meter changes since the last release — nothing to ship. Tick allow_empty to force a rebuild."; exit 1
+            fi
+            [ "$CODE" -ne 0 ] && { echo "::error::compute-version failed (exit $CODE)"; exit "$CODE"; }
+            RC_TAG=""
+            MODE="direct"
+          else
+            git fetch --tags -q
+            if [ -z "$CAND" ]; then
+              RC_TAG=$(git -c versionsort.suffix=-rc tag -l 'tbh-meter-v*-rc.*' --sort=-v:refname | head -n1)
+              [ -z "$RC_TAG" ] && { echo "::error::No staged RC to ship. Merge meter work first, or use direct_from_main."; exit 1; }
+            else
+              RC_TAG="tbh-meter-v${CAND#tbh-meter-v}"
+            fi
+            git rev-parse -q --verify "refs/tags/$RC_TAG" >/dev/null || { echo "::error::Tag $RC_TAG does not exist."; exit 1; }
+            SHA=$(git rev-parse "$RC_TAG^{commit}")
+            RC_VERSION="${RC_TAG#tbh-meter-v}"
+            VERSION="${RC_VERSION%%-*}"   # strip the -rc.N suffix
+            MODE="promote"
+          fi
+
+          STABLE_TAG="tbh-meter-v$VERSION"
+
+          # Downgrade guard: never ship a version ≤ the current Latest stable.
+          HIGHEST=$(git -c versionsort.suffix=-rc tag -l 'tbh-meter-v*' --sort=-v:refname \
+            | grep -E '^tbh-meter-v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)
+          if [ -n "$HIGHEST" ]; then
+            HV="${HIGHEST#tbh-meter-v}"
+            TOP=$(printf '%s\n%s\n' "$VERSION" "$HV" | sort -V | tail -n1)
+            if [ "$VERSION" != "$HV" ] && [ "$TOP" = "$HV" ]; then
+              echo "::error::$VERSION ≤ current stable $HV — refusing a downgrade. Stage a newer RC or bump the floor."; exit 1
+            fi
+          fi
+
+          # Idempotency / repair: a clean tag at the SAME sha = a legit re-ship (allowed); a
+          # DIFFERENT sha = this version already shipped from other code → refuse (bump instead).
+          EXIST_SHA=$(git ls-remote origin "refs/tags/$STABLE_TAG" | cut -f1)
+          if [ -n "$EXIST_SHA" ] && [ "$EXIST_SHA" != "$SHA" ]; then
+            echo "::error::$STABLE_TAG already shipped from ${EXIST_SHA:0:7} (≠ ${SHA:0:7}) — bump instead of re-shipping."; exit 1
+          fi
+
+          echo "::notice::Shipping $VERSION from ${SHA:0:7} ($MODE)"
+          {
+            echo "sha=$SHA"
+            echo "version=$VERSION"
+            echo "stable_tag=$STABLE_TAG"
+            echo "rc_tag=${RC_TAG:-}"
+            echo "mode=$MODE"
+            echo "version_matrix=[\"$VERSION\"]"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build
+    needs: resolve
+    permissions:
+      contents: read
+    # Matrix value surfaces the computed version in the sidebar job name (build (0.31.0)).
+    strategy:
+      matrix:
+        version: ${{ fromJSON(needs.resolve.outputs.version_matrix) }}
+    uses: ./.github/workflows/meter-build-core.yml
+    with:
+      ref: ${{ needs.resolve.outputs.sha }}
+      version: ${{ matrix.version }}
+      variant: stable
+
+  publish:
+    name: Publish + flag Latest
+    needs: [resolve, build]
+    runs-on: ubuntu-latest
+    # Only this job ships: publishes the release + pushes the stable source tag (git push) in
+    # this repo → needs contents: write + the persisted default token. The `production`
+    # environment is the human approval gate + the scope for DISCORD_ANNOUNCE_WEBHOOK.
+    permissions:
+      contents: write
+    timeout-minutes: 20
+    environment: production
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: tbh-meter-stable-windows
+          path: dist
+
+      - name: Publish, tag, and sweep stale drafts
+        id: ship
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # publishes the release in this repo
+          NOTES_TOKEN: ${{ secrets.GITHUB_TOKEN }} # reads THIS repo for the changelog
+          VERSION: ${{ needs.resolve.outputs.version }}
+          STABLE_TAG: ${{ needs.resolve.outputs.stable_tag }}
+          RC_TAG: ${{ needs.resolve.outputs.rc_tag }}
+          SHA: ${{ needs.resolve.outputs.sha }}
+        run: |
+          RELEASES_REPO="$GITHUB_REPOSITORY"
+          TAG="$STABLE_TAG"
+
+          # Outgoing Latest, captured BEFORE the flip (Discord changelog range).
+          PREV_TAG=$(gh api "repos/$RELEASES_REPO/releases/latest" --jq .tag_name 2>/dev/null || true)
+          echo "prev_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
+
+          # End-user notes: download + SmartScreen + auto changelog from THIS repo at the built sha.
+          CHANGELOG=$(GH_TOKEN="$NOTES_TOKEN" gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+            -f tag_name="$TAG" -f target_commitish="$SHA" --jq .body 2>/dev/null || true)
+          {
+            echo "## Download"
+            echo
+            echo "Grab the **\`Setup\`** \`.exe\` and run it — it installs the app and keeps itself"
+            echo "up to date automatically."
+            echo
+            echo "## \"Windows protected your PC\" warning"
+            echo
+            echo "These builds are **not code-signed**, so SmartScreen shows a blue warning the first"
+            echo "time you run them. Click **More info → Run anyway**. If your antivirus quarantines"
+            echo "**tbh-reader.exe**, allow/restore it (bundled Python reader)."
+            echo
+            echo "---"
+            echo
+            echo "$CHANGELOG"
+          } > release-notes.md
+
+          # Draft-FIRST: upload all assets to a draft, THEN flip to published+Latest in one edit,
+          # so electron-updater never sees a Latest without latest.yml/installer (no empty window).
+          if gh release view "$TAG" --repo "$RELEASES_REPO" >/dev/null 2>&1; then
+            echo "Release $TAG exists — refreshing assets + re-flagging Latest (repair/re-ship)."
+            gh release upload "$TAG" dist/*.exe dist/latest.yml dist/*.blockmap --repo "$RELEASES_REPO" --clobber
+            gh release edit "$TAG" --repo "$RELEASES_REPO" \
+              --title "tbh-meter v$VERSION" --notes-file release-notes.md \
+              --draft=false --prerelease=false --latest
+          else
+            gh release create "$TAG" --repo "$RELEASES_REPO" --draft \
+              --title "tbh-meter v$VERSION" --notes-file release-notes.md
+            gh release upload "$TAG" dist/*.exe dist/latest.yml dist/*.blockmap --repo "$RELEASES_REPO" --clobber
+            gh release edit "$TAG" --repo "$RELEASES_REPO" --draft=false --prerelease=false --latest
+          fi
+
+          # Source tag at the BUILT sha — plain push, never forced. Same-sha re-push = no-op;
+          # a different sha was refused in resolve (and is rejected here too as a backstop).
+          EXIST_SHA=$(git ls-remote origin "refs/tags/$TAG" | cut -f1)
+          if [ -z "$EXIST_SHA" ]; then
+            git tag "$TAG" "$SHA"
+            git push origin "refs/tags/$TAG"
+            echo "tag_pushed=true" >> "$GITHUB_OUTPUT"
+            echo "Pushed $TAG at ${SHA:0:7}."
+          elif [ "$EXIST_SHA" = "$SHA" ]; then
+            echo "tag_pushed=false" >> "$GITHUB_OUTPUT"
+            echo "$TAG already at ${SHA:0:7} — no tag push (idempotent re-ship)."
+          else
+            echo "::error::$TAG exists at ${EXIST_SHA:0:7} ≠ built ${SHA:0:7}."; exit 1
+          fi
+
+          # GC: drop every RC/legacy draft whose clean base ≤ the shipped version — clears the
+          # promoted stream AND abandoned ones (e.g. 0.24.1-rc.* once 0.25.0 ships, and the old
+          # sha-suffixed throwaway drafts). PR slots (tbh-meter-pr-*) are left for Meter 1's
+          # PR-close cleanup. Newer staged streams (> shipped) are preserved.
+          # Best-effort, fully wrapped: the ship is already complete (tag pushed, Latest flipped),
+          # so NOTHING here may fail the step — a red step would also skip the Discord announce.
+          {
+            gh api "repos/$RELEASES_REPO/releases" --paginate \
+              --jq '.[] | select(.draft==true) | "\(.id) \(.tag_name)"' | while read -r id t; do
+              case "$t" in
+                tbh-meter-v*-rc.*)
+                  cb="${t#tbh-meter-v}"; cb="${cb%%-*}"
+                  top=$(printf '%s\n%s\n' "$cb" "$VERSION" | sort -V | tail -n1)
+                  if [ "$top" = "$VERSION" ]; then
+                    gh api -X DELETE "repos/$RELEASES_REPO/releases/$id" \
+                      && echo "GC: removed stale draft $t" \
+                      || echo "::warning::GC: could not remove draft $t"
+                  fi
+                  ;;
+              esac
+            done
+          } || echo "::warning::GC sweep skipped (listing failed; ship unaffected)"
+
+      - name: Verify players can see it
+        shell: bash
+        env:
+          TAG: ${{ needs.resolve.outputs.stable_tag }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          RELEASES_REPO="mad-labs-org/tbh-meter-releases"
+          # Installed apps resolve "Latest" through the anonymous 302 on /releases/latest
+          # (electron-updater reads the redirect's tag, then pulls latest.yml under it).
+          # The flip above is an API write; what GitHub SERVES can lag it by a moment — and
+          # players (and we) open the meter the second this run goes green, expecting the
+          # boot update. v0.31.0: a boot seconds around the flip concluded "up to date" and
+          # the app stayed blind for the 10–30 min recheck window. Hold the green until the
+          # public pointer + latest.yml actually serve this ship, polling EXACTLY what a
+          # player's app requests (no token on purpose). Warn-only: the ship itself
+          # (assets, Latest flip, tag) is already complete.
+          SEEN=""
+          for i in $(seq 1 24); do
+            SEEN=$(curl -sI --max-time 10 "https://github.com/$RELEASES_REPO/releases/latest" \
+              | tr -d '\r' | awk 'tolower($1)=="location:" {n=split($2,a,"/"); print a[n]; exit}' || true)
+            if [ "$SEEN" = "$TAG" ]; then
+              echo "Public /releases/latest serves $TAG (attempt $i)."
+              break
+            fi
+            sleep 5
+          done
+          if [ "$SEEN" != "$TAG" ]; then
+            echo "::warning::/releases/latest still serves '${SEEN:-nothing}' (≠ $TAG) after ~2 min — a just-restarted app may briefly miss this update."
+          fi
+          YML_VER=$(curl -sL --max-time 15 "https://github.com/$RELEASES_REPO/releases/download/$TAG/latest.yml" \
+            | awk '$1=="version:" {print $2; exit}' || true)
+          if [ "$YML_VER" = "$VERSION" ]; then
+            echo "latest.yml under $TAG serves version $YML_VER."
+          else
+            echo "::warning::latest.yml under $TAG serves '${YML_VER:-nothing}' (expected $VERSION)."
+          fi
+
+      - name: Announce on Discord (only when the tag was newly pushed)
+        if: steps.ship.outputs.tag_pushed == 'true'
+        shell: bash
+        env:
+          DISCORD_ANNOUNCE_WEBHOOK: ${{ secrets.DISCORD_ANNOUNCE_WEBHOOK }}
+          PREV_TAG: ${{ steps.ship.outputs.prev_tag }}
+          TAG: ${{ needs.resolve.outputs.stable_tag }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          if [ -z "$DISCORD_ANNOUNCE_WEBHOOK" ]; then
+            echo "DISCORD_ANNOUNCE_WEBHOOK not set — skipping announcement."; exit 0
+          fi
+          if ! git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "Tag $TAG not in this checkout — skipping announcement."; exit 0
+          fi
+          if [ -n "$PREV_TAG" ] && ! git rev-parse -q --verify "refs/tags/$PREV_TAG" >/dev/null; then
+            echo "Previous tag $PREV_TAG not in this checkout — announcing full history."
+            PREV_TAG=""
+          fi
+          RANGE="${PREV_TAG:+$PREV_TAG..}$TAG"
+          SUBJECTS=$(git log "$RANGE" --no-merges --pretty=%s -- app reader data)
+          FEATURES=$(grep -E '^feat(\([^)]*\))?!?:' <<< "$SUBJECTS" | sed -E 's/^feat(\([^)]*\))?!?:[[:space:]]*/- /' || true)
+          FIXES=$(grep -E '^fix(\([^)]*\))?!?:' <<< "$SUBJECTS" | sed -E 's/^fix(\([^)]*\))?!?:[[:space:]]*/- /' || true)
+          if [ -z "$FEATURES" ] && [ -z "$FIXES" ]; then
+            echo "No feat/fix commits since ${PREV_TAG:-(none)} — skipping announcement."; exit 0
+          fi
+          DESC=""
+          [ -n "$FEATURES" ] && DESC="**New features**\n$FEATURES"
+          [ -n "$FIXES" ] && DESC="${DESC:+$DESC\n\n}**Fixes**\n$FIXES"
+          DESC=$(printf '%b' "$DESC")
+          jq -n \
+            --arg title "TBH Meter v$VERSION" \
+            --arg desc "$DESC" \
+            --arg url "https://github.com/mad-labs-org/tbh-meter-releases/releases/tag/$TAG" \
+            '{
+              username: "TBH Helper",
+              embeds: [{
+                title: ("🚀 " + $title),
+                url: $url,
+                description: $desc,
+                color: 5201407,
+                footer: { text: "Installed apps update themselves automatically." },
+                timestamp: (now | todate)
+              }],
+              allowed_mentions: { parse: [] }
+            }' \
+            | curl -sf -X POST -H 'Content-Type: application/json' -d @- "$DISCORD_ANNOUNCE_WEBHOOK" \
+            || echo "::warning::Discord announcement failed (the ship itself is unaffected)."
+
+      - name: Job summary
+        if: always()
+        shell: bash
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+          STABLE_TAG: ${{ needs.resolve.outputs.stable_tag }}
+          RC_TAG: ${{ needs.resolve.outputs.rc_tag }}
+          MODE: ${{ needs.resolve.outputs.mode }}
+          SHA: ${{ needs.resolve.outputs.sha }}
+          TAG_PUSHED: ${{ steps.ship.outputs.tag_pushed }}
+        run: |
+          {
+            echo "## 🚀 Shipped to players"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| **Version** | \`$VERSION\` |"
+            echo "| **From** | ${MODE} · \`${SHA:0:7}\`${RC_TAG:+ (from \`$RC_TAG\`)} |"
+            echo "| **Latest tag** | \`$STABLE_TAG\` |"
+            echo
+            echo "Installed apps self-update via electron-updater (\`/releases/latest\`)."
+            echo "Release: https://github.com/mad-labs-org/tbh-meter-releases/releases/tag/$STABLE_TAG"
+            if [ "$TAG_PUSHED" != "true" ]; then
+              echo
+              echo "> ℹ️ This was an idempotent re-ship (tag already at this commit), so the Discord"
+              echo "> announcement was skipped. To announce manually, post the release link above."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/meter-build-core.yml
+++ b/.github/workflows/meter-build-core.yml
@@ -16,7 +16,7 @@
 #            Used for staged-RC builds AND throwaway PR builds — never clobbers a real install.
 #   stable → the shipped app: normal appId/data dir, auto-update ON. Emits latest.yml +
 #            .blockmap (electron-updater needs them).
-name: TBH Meter / core build (internal)
+name: Release · core build
 
 on:
   workflow_call:

--- a/.github/workflows/meter-build-core.yml
+++ b/.github/workflows/meter-build-core.yml
@@ -1,0 +1,150 @@
+# TBH Meter / core build (INTERNAL — reusable, never in the dispatch list).
+#
+# Produces ONE tbh-meter installer for an EXACT commit + version, in either variant, and
+# uploads it as a run artifact. Both step 2 (Build test version) and step 3 (Release) call
+# this via `workflow_call`, so the Windows build (reader exe + electron-builder) lives in
+# ONE place instead of the ~80 duplicated lines the old release/promote workflows carried.
+#
+# It only BUILDS + uploads — it never publishes a release or pushes a tag. The caller owns
+# publishing (draft for a test build, Latest for a ship), so this needs no release token and
+# the same build definition serves both channels. The caller passes the exact `version`
+# (computed once, up front) so the in-app version and installer filename match byte-for-byte.
+#
+# variant:
+#   rc     → side-by-side test build: appId `wiki.tbh.meter.rc`, productName `tbh-meter-rc`,
+#            data dir `~/tbh-meter-rc`, auto-update OFF (TBH_BUILD_VARIANT=rc → __TBH_VARIANT__).
+#            Used for staged-RC builds AND throwaway PR builds — never clobbers a real install.
+#   stable → the shipped app: normal appId/data dir, auto-update ON. Emits latest.yml +
+#            .blockmap (electron-updater needs them).
+name: TBH Meter / core build (internal)
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Exact commit SHA to build."
+        required: true
+        type: string
+      version:
+        description: "Exact version to stamp (e.g. 0.31.0-rc.2 · 0.31.0 · 0.0.0-pr.342.57)."
+        required: true
+        type: string
+      variant:
+        description: "rc = side-by-side test build (auto-update OFF); stable = the shipped app."
+        required: true
+        type: string
+    outputs:
+      artifact:
+        description: "Name of the uploaded build artifact (tbh-meter-<variant>-windows)."
+        value: tbh-meter-${{ inputs.variant }}-windows
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: app
+
+jobs:
+  build:
+    name: build ${{ inputs.variant }} ${{ inputs.version }}
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          package_json_file: app/package.json
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: app/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Stamp the exact version into package.json
+        shell: bash
+        # --set stamps the chosen version verbatim (no recompute → no drift), so the installer
+        # filename and app.getVersion() both read exactly inputs.version.
+        run: node scripts/compute-version.mjs --set "${{ inputs.version }}" --write
+
+      # --- Reader sidecar (tbh-reader.exe) — identical for both variants -----------------
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install PyInstaller
+        working-directory: reader
+        run: pip install pyinstaller
+
+      - name: Build reader exe (tbh-reader.exe)
+        working-directory: reader
+        # onefile → a single dist\tbh-reader.exe. --add-data ";" is the Windows separator;
+        # bundles level_curve.json + skill_attr_map.json + the calib seed (first launch on a
+        # shipped build skips the ~70s scan; a missing seed file makes PyInstaller fail loud).
+        run: pyinstaller --noconfirm --clean --name tbh-reader --onefile --console --paths . --add-data "config/level_curve.json;config" --add-data "config/skill_attr_map.json;config" --add-data "config/calib_seed.json;config" meter_windows.py
+
+      - name: Smoke test reader exe (--selftest must exit 0)
+        working-directory: reader
+        run: |
+          .\dist\tbh-reader.exe --selftest
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "tbh-reader.exe --selftest exited with $LASTEXITCODE"
+            exit 1
+          }
+
+      - name: Bundle reader exe into app resources
+        working-directory: .
+        run: |
+          New-Item -ItemType Directory -Force -Path app/resources/reader | Out-Null
+          Copy-Item -Force reader/dist/tbh-reader.exe app/resources/reader/tbh-reader.exe
+
+      - name: Build the ${{ inputs.variant }} installer
+        shell: bash
+        env:
+          # rc → ~/tbh-meter-rc + auto-update OFF; stable (anything else) → defaults to the
+          # shipped identity. electron.vite.config.ts bakes this into __TBH_VARIANT__.
+          TBH_BUILD_VARIANT: ${{ inputs.variant }}
+        run: |
+          if [ "${{ inputs.variant }}" = "rc" ]; then
+            pnpm build
+            # CLI -c.<path> overrides give the RC its own identity so it installs side-by-side
+            # with the real app. --publish never: the caller attaches the asset itself.
+            # shellcheck disable=SC2016  # ${version}/${ext} are electron-builder templates, not shell vars
+            pnpm exec electron-builder --win \
+              -c.appId=wiki.tbh.meter.rc \
+              -c.productName=tbh-meter-rc \
+              -c.nsis.shortcutName=tbh-meter-rc \
+              -c.nsis.uninstallDisplayName=tbh-meter-rc \
+              -c.nsis.artifactName='tbh-meter-rc-Setup-${version}.${ext}' \
+              --publish never
+          else
+            # dist:win = `pnpm build && electron-builder --win`; --publish never (caller attaches).
+            pnpm dist:win --publish never
+          fi
+
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tbh-meter-${{ inputs.variant }}-windows
+          # The .exe always exists; latest.yml + .blockmap exist for stable (electron-updater
+          # needs them) and are harmless extras for rc. if-no-files-found:error guards a broken
+          # build (no installer produced).
+          path: |
+            app/dist/*.exe
+            app/dist/latest.yml
+            app/dist/*.blockmap
+          if-no-files-found: error
+          # Throwaway handoff: build-core is workflow_called and the installer is consumed within
+          # the same run (the durable copy ships to the tbh-meter-releases Release). 1 day is the
+          # floor and keeps these large Electron+reader bundles from filling the Actions quota.
+          retention-days: 1

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,4 +1,4 @@
-name: Secret scan
+name: Security · secret scan
 
 # Fails the build if a secret is committed. Scans full git history with gitleaks, using the
 # allowlist in .gitleaks.toml. Runs the binary directly (no marketplace action) so it does not
@@ -12,7 +12,8 @@ permissions:
   contents: read
 
 jobs:
-  gitleaks:
+  scan:
+    name: secret scan
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## What & why

Brings **all the workflows** into the repo, reworked from the cross-repo model (private source → `RELEASES_TOKEN` → public releases repo) into the **same-repo model**: the source, the pipeline, and the release artifacts now live here, so everything publishes via the default `GITHUB_TOKEN` and the cross-repo PAT is gone.

Still **no source code** — the workflows are staged and scoped so nothing fires (or fails) before `app/`/`reader/` land.

## Files

| File | Role |
|---|---|
| `ci.yml` | app (`pnpm check`/`test`) + reader (`ruff`/`pytest`) gates |
| `meter-1-stage.yml` | auto RC tag on meter changes + PR test-build cleanup |
| `meter-2-build.yml` | manual RC test build → **draft release here** |
| `meter-3-ship.yml` | manual stable build → **Latest + tag + Discord** |
| `meter-build-core.yml` | internal reusable Windows build (reader exe + installer) |
| `dependabot.yml` | `github-actions` live; `npm`/`pip` commented until the code lands |

## Same-repo changes vs the source workflows

- `secrets.RELEASES_TOKEN` → `secrets.GITHUB_TOKEN` everywhere.
- `RELEASES_REPO` → `$GITHUB_REPOSITORY` (self-referential).
- Publish jobs gained `contents: write` (they now create releases in this repo).

## Why nothing breaks before the code

- **`ci.yml`** is path-filtered to `app|reader|data` → never runs until those exist (so it can't redden `main` when this file merges).
- **`meter-1-stage`** `stage` triggers only on `app|reader|data` pushes; the self-referencing workflow paths were intentionally left out for now. Its `clean-pr-slot` runs on PR close and safely no-ops (no draft to delete).
- **`meter-2/3/core`** are `workflow_dispatch`/`workflow_call` only — they don't run on their own.

## Follow-ups (with the code)

- Re-add the pipeline workflow paths to `meter-1-stage` triggers; uncomment `npm`/`pip` in `dependabot.yml`.
- `meter-3-ship` uses the `production` environment + `DISCORD_ANNOUNCE_WEBHOOK` secret — configure both before the first ship.