### PR TITLE
ci: require a linked issue + Conventional Commits PR title

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,4 +1,4 @@
-name: PR title
+name: Check · PR title
 
 # Enforces Conventional Commits on the PR title. Titles are load-bearing: the release pipeline
 # derives the version (feat→minor, fix→patch, !→major) and the changelog from commit subjects,

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,28 @@
+name: PR title
+
+# Enforces Conventional Commits on the PR title. Titles are load-bearing: the release pipeline
+# derives the version (feat→minor, fix→patch, !→major) and the changelog from commit subjects,
+# and a squash-merge uses the PR title as that subject. Inline check — no third-party action.
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  conventional-title:
+    name: conventional commits
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate PR title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if printf '%s' "$TITLE" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9 ._/-]+\))?!?: .+'; then
+            echo "OK: $TITLE"
+          else
+            echo "::error::PR title must follow Conventional Commits — e.g. 'feat(app): add follow-window toggle'."
+            echo "::error::Allowed types: feat fix docs style refactor perf test build ci chore revert. Got: '$TITLE'"
+            exit 1
+          fi

--- a/.github/workflows/require-issue.yml
+++ b/.github/workflows/require-issue.yml
@@ -1,0 +1,43 @@
+name: Require linked issue
+
+# Every PR must close an issue ("no PR without an issue"). Reads the PR's real issue linkage
+# (closingIssuesReferences — populated by "Closes #N" in the body or the Development panel),
+# not a regex. Bot PRs are exempt but still report success (never "skipped"), so this stays
+# safe to mark as a REQUIRED status check in the branch ruleset.
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  require-issue:
+    name: linked issue
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify the PR closes an issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PR: ${{ github.event.pull_request.number }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          case "$ACTOR" in
+            "dependabot[bot]"|"github-actions[bot]")
+              echo "Bot PR ($ACTOR) — exempt."; exit 0;;
+          esac
+          COUNT=$(gh api graphql -f query='
+            query($owner:String!,$repo:String!,$pr:Int!){
+              repository(owner:$owner,name:$repo){
+                pullRequest(number:$pr){ closingIssuesReferences(first:1){ totalCount } }
+              }
+            }' -F owner="$OWNER" -F repo="$REPO" -F pr="$PR" \
+            --jq '.data.repository.pullRequest.closingIssuesReferences.totalCount')
+          if [ "${COUNT:-0}" -lt 1 ]; then
+            echo "::error::This PR is not linked to an issue. Add 'Closes #<number>' to the description (or link one via the Development panel) — every change starts from an issue."
+            exit 1
+          fi
+          echo "OK — this PR closes ${COUNT} issue(s)."

--- a/.github/workflows/require-issue.yml
+++ b/.github/workflows/require-issue.yml
@@ -1,4 +1,4 @@
-name: Require linked issue
+name: Check · linked issue
 
 # Every PR must close an issue ("no PR without an issue"). Reads the PR's real issue linkage
 # (closingIssuesReferences — populated by "Closes #N" in the body or the Development panel),


### PR DESCRIPTION
Closes #7

## What & why

First slice of the guardrail suite (now affordable: public repo = free unlimited Actions). Two **inline** checks — no third-party actions, in the same "run it directly" spirit as the gitleaks scan.

- **`require-issue.yml`** — every PR must close an issue. Reads the PR's real `closingIssuesReferences` (populated by `Closes #N` or the Development panel), not a body regex. Bots (`dependabot[bot]`, `github-actions[bot]`) are exempt but **still report success** — so it's safe to mark as a required status check.
- **`pr-title.yml`** — the PR title must be a Conventional Commit. Load-bearing: the release pipeline derives the version and changelog from commit subjects (and a squash-merge uses the PR title).

## Next (after this merges)

- **Harden the `main` ruleset**: required approval + code-owner review + required checks (`gitleaks`, `linked issue`, `conventional commits`) + your admin bypass.
- Add **OpenSSF Scorecard**, **actionlint** (SHA-pinned).
- **CodeQL** + **Dependency Review** land with the source.

This PR itself links an issue (#7) and uses a Conventional Commit title, so both new checks go green on it.