### PR TITLE
chore: require owner review for any .github/ change

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,8 +4,12 @@
 # "Require review from Code Owners" in the main branch ruleset.
 # Docs: https://docs.github.com/articles/about-code-owners
 
-# Default for everything (including data/ and .github/): all maintainers.
+# Default for everything (including data/): all maintainers.
 *           @marioalvial @viniarruda @pedrobullo
+
+# CI, the release pipeline, and repo automation — these touch secrets and what runs on
+# every PR, so any change here requires the repo owner's review specifically.
+/.github/   @marioalvial
 
 # Electron overlay app.
 /app/       @marioalvial @viniarruda @pedrobullo


### PR DESCRIPTION
Closes #15

Part of locking down what a write-level contributor can affect. Makes `/.github/` owned by **@marioalvial** only, so any workflow / CI / automation change requires the owner's review (not just any maintainer).

Companion mitigations already applied via repo config:
- **`production` environment** — required reviewer @marioalvial, deploys only from protected `main`; release secrets live here, so PR branches can't read them.
- **`no-branch-deletion` ruleset** (all branches) — only the admin can delete branches.