### PR TITLE
ci: add OpenSSF Scorecard + actionlint (pinned, checksum-verified)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,35 @@
+name: Check · workflows
+
+# Lints the GitHub Actions workflow files (syntax, expression types, event/glob validity, and
+# shell via shellcheck). Runs only when a workflow changes. The actionlint binary is pinned to a
+# version AND checksum-verified against the release's published checksums (no blind curl|bash).
+on:
+  pull_request:
+    paths: [".github/workflows/**"]
+  push:
+    branches: [main]
+    paths: [".github/workflows/**"]
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint (pinned + checksum-verified)
+        run: |
+          version=1.7.12
+          base="https://github.com/rhysd/actionlint/releases/download/v${version}"
+          file="actionlint_${version}_linux_amd64.tar.gz"
+          curl -sSfL "$base/$file" -o "$file"
+          curl -sSfL "$base/actionlint_${version}_checksums.txt" -o checksums.txt
+          grep -F "$file" checksums.txt | sha256sum -c -
+          tar -xzf "$file" actionlint
+          ./actionlint -color

--- a/.github/workflows/require-issue.yml
+++ b/.github/workflows/require-issue.yml
@@ -29,6 +29,8 @@ jobs:
             "dependabot[bot]"|"github-actions[bot]")
               echo "Bot PR ($ACTOR) — exempt."; exit 0;;
           esac
+          # $owner/$repo/$pr below are GraphQL variables (bound via -F), not shell vars.
+          # shellcheck disable=SC2016
           COUNT=$(gh api graphql -f query='
             query($owner:String!,$repo:String!,$pr:Int!){
               repository(owner:$owner,name:$repo){

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,45 @@
+name: Security · Scorecard
+
+# OpenSSF Scorecard — scores the repo's supply-chain security posture (branch protection, pinned
+# deps, token permissions, dangerous workflow patterns, etc.) and publishes the results to the
+# Security tab (code scanning) and the public OpenSSF registry. Not a PR gate.
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "27 3 * * 1" # weekly, Monday 03:27 UTC
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: scorecard
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      security-events: write # upload the SARIF result to code scanning
+      id-token: write # publish results to the OpenSSF registry (public repo)
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@c35d1b164463ee62a100735382aaaa525c5d3496 # codeql-bundle-v2.25.6
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Closes #19

Finishes the **code-independent** guardrails:

- **`Security · Scorecard`** — OpenSSF Scorecard; results to the Security tab (code scanning) + the public OpenSSF registry. Runs on schedule, push to `main`, and branch-protection changes (not a PR gate). All actions SHA-pinned.
- **`Check · workflows`** — actionlint on workflow changes. The binary is pinned to **v1.7.12 and checksum-verified** against the release's published checksums (addresses the earlier 'no blind curl|bash' point).

Also silences one false-positive `SC2016` in `require-issue.yml` (the `$owner/$repo/$pr` are GraphQL variables, not shell vars) so actionlint is clean. Verified locally with shellcheck: **actionlint passes on all workflows**.

Remaining guardrails (CodeQL + Dependency Review) need the source, so they land with the code.