### PR TITLE
ci: add CodeQL + Dependency Review; re-enable meter-1 self-staging

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: Security · CodeQL
+
+# CodeQL static analysis (SAST) of the source — JS/TS (app) and Python (reader). Reports to the
+# Security tab. Runs on push to main, on PRs that touch the source, and weekly. Not a PR gate.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - "app/**"
+      - "reader/**"
+      - ".github/workflows/codeql.yml"
+  schedule:
+    - cron: "33 4 * * 2" # weekly, Tuesday 04:33 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: codeql (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write # upload results to code scanning
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, python]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c35d1b164463ee62a100735382aaaa525c5d3496 # codeql-bundle-v2.25.6
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@c35d1b164463ee62a100735382aaaa525c5d3496 # codeql-bundle-v2.25.6
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,25 @@
+name: Security · dependencies
+
+# Dependency Review — on every PR, flags any added/changed dependency that carries a known
+# vulnerability (or an incompatible license) before it merges. No-op on PRs that don't touch
+# a manifest.
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: dependency review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/meter-1-stage.yml
+++ b/.github/workflows/meter-1-stage.yml
@@ -30,9 +30,8 @@ on:
       - "app/**"
       - "reader/**"
       - "data/**"
-      # NOTE: the pipeline workflow files are deliberately NOT listed here yet. Until the source
-      # (app/, reader/) lands, a self-referencing path would fire `stage` on a pipeline-only edit
-      # and fail (no compute-version.mjs). Re-add them in the PR that brings the code.
+      - ".github/workflows/meter-1-stage.yml"
+      - ".github/workflows/meter-build-core.yml"
   pull_request:
     types: [closed]
 


### PR DESCRIPTION
Closes #23

Now that the source is on `main`:
- **`Security · CodeQL`** — SAST for app (JS/TS) + reader (Python), SHA-pinned, results to the Security tab.
- **`Security · dependencies`** — Dependency Review on PRs.
- **`meter-1-stage`** — re-added the pipeline workflow paths (safe now that `compute-version.mjs` exists).

(Re-do of the closed #24, which got orphaned when #22 squash-merged. actionlint clean; CodeQL verified green on the prior run.)