### PR TITLE
chore: re-point auto-update + references to the renamed repo (tbh-meter)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -77,7 +77,7 @@ always releasable. Everything lands through a pull request; nobody pushes to `ma
 
 You need **no access to this repo** to contribute — the standard open-source flow:
 
-1. **Fork** the repository (UI "Fork" button, or `gh repo fork mad-labs-org/tbh-meter-releases --clone`).
+1. **Fork** the repository (UI "Fork" button, or `gh repo fork mad-labs-org/tbh-meter --clone`).
 2. In your fork, branch off `main` (`fix/…`, `feat/…`) and commit your work.
 3. **Open a pull request** against `main` here. Start every change from an issue and reference it
    (`Closes #123` in the PR description).

--- a/.github/workflows/meter-1-stage.yml
+++ b/.github/workflows/meter-1-stage.yml
@@ -135,7 +135,7 @@ jobs:
             echo "2. Install & smoke-test it on Windows."
             echo "3. **[TBH Meter / 3. Release to players]($ACTIONS/workflows/meter-3-ship.yml)** — no input needed (ships this newest RC)."
             echo
-            echo "Builds land on [tbh-meter-releases](https://github.com/mad-labs-org/tbh-meter-releases/releases)."
+            echo "Builds land on [tbh-meter](https://github.com/mad-labs-org/tbh-meter/releases)."
           } >> "$GITHUB_STEP_SUMMARY"
 
   clean-pr-slot:

--- a/.github/workflows/meter-3-ship.yml
+++ b/.github/workflows/meter-3-ship.yml
@@ -284,7 +284,7 @@ jobs:
           TAG: ${{ needs.resolve.outputs.stable_tag }}
           VERSION: ${{ needs.resolve.outputs.version }}
         run: |
-          RELEASES_REPO="mad-labs-org/tbh-meter-releases"
+          RELEASES_REPO="mad-labs-org/tbh-meter"
           # Installed apps resolve "Latest" through the anonymous 302 on /releases/latest
           # (electron-updater reads the redirect's tag, then pulls latest.yml under it).
           # The flip above is an API write; what GitHub SERVES can lag it by a moment — and
@@ -348,7 +348,7 @@ jobs:
           jq -n \
             --arg title "TBH Meter v$VERSION" \
             --arg desc "$DESC" \
-            --arg url "https://github.com/mad-labs-org/tbh-meter-releases/releases/tag/$TAG" \
+            --arg url "https://github.com/mad-labs-org/tbh-meter/releases/tag/$TAG" \
             '{
               username: "TBH Helper",
               embeds: [{
@@ -385,7 +385,7 @@ jobs:
             echo "| **Latest tag** | \`$STABLE_TAG\` |"
             echo
             echo "Installed apps self-update via electron-updater (\`/releases/latest\`)."
-            echo "Release: https://github.com/mad-labs-org/tbh-meter-releases/releases/tag/$STABLE_TAG"
+            echo "Release: https://github.com/mad-labs-org/tbh-meter/releases/tag/$STABLE_TAG"
             if [ "$TAG_PUSHED" != "true" ]; then
               echo
               echo "> ℹ️ This was an idempotent re-ship (tag already at this commit), so the Discord"

--- a/.github/workflows/meter-build-core.yml
+++ b/.github/workflows/meter-build-core.yml
@@ -154,6 +154,6 @@ jobs:
             app/dist/*.blockmap
           if-no-files-found: error
           # Throwaway handoff: build-core is workflow_called and the installer is consumed within
-          # the same run (the durable copy ships to the tbh-meter-releases Release). 1 day is the
+          # the same run (the durable copy ships to the tbh-meter Release). 1 day is the
           # floor and keeps these large Electron+reader bundles from filling the Actions quota.
           retention-days: 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ pipeline:
    `app/`, `reader/`, `data/` changed** (the P1 guard, enforced in `compute-version.mjs`). Also, on
    **any PR close**, deletes that PR's throwaway test-build draft (`tbh-meter-pr-<N>`).
 2. **`meter-2-build.yml` · "TBH Meter / 2. Build test version to download"** — manual. Builds the **RC
-   variant** and publishes a **DRAFT** on the public `mad-labs-org/tbh-meter-releases` repo
+   variant** and publishes a **DRAFT** on the public `mad-labs-org/tbh-meter` repo
    (invisible to anonymous users + electron-updater). Blank = newest staged RC; `candidate=<ver>` = a
    specific RC; `pr=<N>` = a throwaway pre-merge build of that PR's head (version
    `0.0.0-pr.<N>.<run>`, link posted as a PR comment). One mutable draft slot per target.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 **A live DPS / Gold / EXP meter & run tracker overlay for [Task Bar Hero](https://store.steampowered.com/)**
 
-[![Latest release](https://img.shields.io/github/v/release/mad-labs-org/tbh-meter-releases?label=latest&color=4c1)](https://github.com/mad-labs-org/tbh-meter-releases/releases/latest)
-[![Downloads](https://img.shields.io/github/downloads/mad-labs-org/tbh-meter-releases/total?color=blue&cacheSeconds=3600)](https://github.com/mad-labs-org/tbh-meter-releases/releases)
-[![Platform](https://img.shields.io/badge/platform-Windows%2010%2B-0078d4)](https://github.com/mad-labs-org/tbh-meter-releases/releases/latest)
+[![Latest release](https://img.shields.io/github/v/release/mad-labs-org/tbh-meter?label=latest&color=4c1)](https://github.com/mad-labs-org/tbh-meter/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/mad-labs-org/tbh-meter/total?color=blue&cacheSeconds=3600)](https://github.com/mad-labs-org/tbh-meter/releases)
+[![Platform](https://img.shields.io/badge/platform-Windows%2010%2B-0078d4)](https://github.com/mad-labs-org/tbh-meter/releases/latest)
 [![Buy Me a Coffee](https://img.shields.io/badge/Buy_Me_a_Coffee-ffdd00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/viniarruda)
 
 <img src=".github/assets/meter-hero.png" width="820" alt="TBH Meter — the Runs history window with the live overlay docked at the bottom-left">
@@ -37,7 +37,7 @@ Every finished run is also saved with full detail — result (success / fail / a
 
 > **Windows 10+ only.** The reader uses Windows APIs to read game memory.
 
-1. Download **`tbh-meter-Setup-<version>.exe`** from the [**latest release**](https://github.com/mad-labs-org/tbh-meter-releases/releases/latest).
+1. Download **`tbh-meter-Setup-<version>.exe`** from the [**latest release**](https://github.com/mad-labs-org/tbh-meter/releases/latest).
 2. Run the installer — **no admin rights needed** (it installs per-user).
 3. Launch Task Bar Hero and TBH Meter in any order. The first attach takes **1–2 minutes**; after that, live stats appear automatically.
 

--- a/app/electron-builder.yml
+++ b/app/electron-builder.yml
@@ -36,7 +36,7 @@ files:
 publish:
   provider: github
   owner: mad-labs-org
-  repo: tbh-meter-releases
+  repo: tbh-meter
 
 win:
   target:

--- a/app/src/main/auto-update.ts
+++ b/app/src/main/auto-update.ts
@@ -43,7 +43,7 @@ const ERROR_RETRIGGER_COOLDOWN_MS = 30_000;
 // so any failure degrades to null = "no signal" and the gate behaves as before.
 // owner/repo must match electron-builder.yml `publish`.
 const RELEASES_LATEST_API_URL =
-  "https://api.github.com/repos/mad-labs-org/tbh-meter-releases/releases/latest";
+  "https://api.github.com/repos/mad-labs-org/tbh-meter/releases/latest";
 const AUTHORITY_TIMEOUT_MS = 3_000;
 // Convergence budget once staleness is KNOWN: 8 × (3s + one check round-trip) ≈ 45s of
 // splash typically. Not a hard wall-clock cap — each re-check is awaited in full so its


### PR DESCRIPTION
Closes #36

The repo was renamed **tbh-meter-releases → tbh-meter** (preserves the ~236k downloads + carries the installed fleet via GitHub's **301 redirect** — verified live).

- **Critical:** `app/electron-builder.yml` `publish.repo` + `app/src/main/auto-update.ts` → new builds fetch updates straight from `tbh-meter`.
- README badges, CONTRIBUTING, CLAUDE.md, and the 4 hardcoded workflow URLs updated.

actionlint + tsc clean locally.