### PR TITLE
docs: bust stale camo cache for installs badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **A live DPS / Gold / EXP meter & run tracker overlay for [Task Bar Hero](https://store.steampowered.com/)**
 
 [![Latest release](https://img.shields.io/github/v/release/mad-labs-org/tbh-meter?label=latest&color=4c1)](https://github.com/mad-labs-org/tbh-meter/releases/latest)
-[![Installs](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmad-labs-org%2Ftbh-meter%2Fbadges%2Finstalls.json&cacheSeconds=3600)](https://github.com/mad-labs-org/tbh-meter/releases)
+[![Installs](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmad-labs-org%2Ftbh-meter%2Fbadges%2Finstalls.json&cacheSeconds=1800)](https://github.com/mad-labs-org/tbh-meter/releases)
 [![Platform](https://img.shields.io/badge/platform-Windows%2010%2B-0078d4)](https://github.com/mad-labs-org/tbh-meter/releases/latest)
 [![Buy Me a Coffee](https://img.shields.io/badge/Buy_Me_a_Coffee-ffdd00?logo=buymeacoffee&logoColor=black)](https://buymeacoffee.com/viniarruda)
 


### PR DESCRIPTION
## What

The installs badge rendered **"resource not found"** on the README — but it's **not** an endpoint
problem. The `badges/installs.json` is healthy and `img.shields.io/endpoint?...` returns
`installs: 13k`. The culprit is GitHub's **Camo** image proxy: during the brief window after this
badge first landed on `main` and before the `badges` branch was bootstrapped, shields returned a
404, and Camo cached that "resource not found" image keyed to the badge URL — so it kept serving the
stale error even after the data went live.

This bumps `cacheSeconds=3600` → `1800`, which changes the image URL just enough to map to a **new
Camo cache key**, forcing GitHub to re-fetch the (now-healthy) badge. Shorter cache also means
faster recovery from any future transient blip.

## Verified
- `raw.githubusercontent.com/mad-labs-org/tbh-meter/badges/installs.json` → `200`, `{"message":"13k"}`
- `img.shields.io/endpoint?...` → `installs: 13k`
- The live README's current Camo URL was confirmed serving the cached `resource not found`; a fresh
  URL sidesteps it.

No workflow change — `installs-badge.yml` keeps publishing the lifetime installer count (daily + on
each release).
