### PR TITLE
docs(app): correct same-repo release comment in electron-builder.yml

### DIFF
--- a/app/electron-builder.yml
+++ b/app/electron-builder.yml
@@ -29,10 +29,10 @@ files:
 # electron-updater resolves the newest build via GitHub's /releases/latest endpoint, so the
 # custom tbh-meter-v<version> tag prefix works as long as that release is flagged "Latest".
 #
-# PUBLIC repo on purpose: the source (tbh-wiki) is PRIVATE, and electron-updater on a user's
-# machine has no GitHub token — it would 404 on a private repo's release assets ("Update
-# check failed"). So releases live in a dedicated PUBLIC repo the app reads anonymously; CI
-# publishes there with a cross-repo token (RELEASES_TOKEN). See meter-3-ship.yml.
+# PUBLIC repo on purpose: electron-updater on a user's machine has no GitHub token — it would
+# 404 on a private repo's release assets ("Update check failed"). So source AND releases live
+# in this one public repo, which the app reads anonymously; CI publishes to this repo's own
+# Releases with the built-in GITHUB_TOKEN (no cross-repo token). See meter-3-ship.yml.
 publish:
   provider: github
   owner: mad-labs-org


### PR DESCRIPTION
## Description

The `publish:` comment in `app/electron-builder.yml` described the old cross-repo release architecture (a dedicated public *releases* repo + a cross-repo `RELEASES_TOKEN`). The same-repo cutover removed that, so the comment contradicted the `publish:` block right below it — which already targets this repo. This rewrites it to describe the same-repo flow: CI publishes to this repo's own Releases with the built-in `GITHUB_TOKEN`.

> ⚠️ **Needs an issue link.** The `Check · linked issue` gate requires `Closes #N`. Creating the issue automatically was blocked, so add `Closes #N` here (or link one via the Development panel) to turn that check green.

## Key changes

- Rewrote the `publish:` comment in `app/electron-builder.yml` to reflect same-repo releases; dropped the stale `RELEASES_TOKEN` / dedicated-releases-repo wording.

## Type of change

- [x] Refactor / chore / docs (no user-visible behavior change)

## How was this tested?

- [x] Comment-only YAML change — no code paths affected (no lint/tsc/test surface)

## Checklist

- [x] Conventional commit subjects — they drive the computed release version and the changelog
- [x] Self-reviewed the diff
- [x] No hand-edits to generated/synced files
- [x] No secrets committed