### PR TITLE
fix(app): make splash window opaque (Electron 42 transparent regression)

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -217,8 +217,10 @@ function openListWindow(): void {
 
 // --------------------------------------------------------------------------- //
 // SPLASH window — Discord-style startup screen. Shown on launch while the reader
-// brings the game's memory up; closes itself once the reader signals "ready" (or the
-// user clicks "Pular"). Frameless + transparent so it floats as a rounded card.
+// brings the game's memory up; dismissed main-side once real data flows (no skip button).
+// Frameless + OPAQUE on purpose: a transparent window let Electron 42's Chromium compose
+// the opaque card as translucent on Windows (the desktop showed through), so we paint an
+// opaque window background instead. Win11 still rounds the corners natively.
 // --------------------------------------------------------------------------- //
 
 function createSplashWindow(): BrowserWindow {
@@ -227,12 +229,12 @@ function createSplashWindow(): BrowserWindow {
     height: SPLASH_HEIGHT,
     center: true,
     frame: false,
-    transparent: true,
+    transparent: false,
     resizable: false,
     alwaysOnTop: true,
     skipTaskbar: true,
     icon: appIconAsset,
-    backgroundColor: "#00000000",
+    backgroundColor: "#0d0e1a",
     show: false,
     webPreferences: commonWebPreferences(),
   });
@@ -254,7 +256,7 @@ let readyDismissTimer: ReturnType<typeof setTimeout> | null = null;
 const READY_FALLBACK_MS = 8000;
 // While the splash is up, watch for the reader going "blocked" (AV keeps killing it):
 // loading can't proceed, so hand off to the overlay's blocked + Retry message rather than
-// trap the user behind a splash that never loads (this replaces the old "Pular" escape).
+// trap the user behind a splash that never loads (this replaced the old manual skip button).
 let splashBlockedWatch: ReturnType<typeof setInterval> | null = null;
 // Safety-net deadline: a reader stuck on "searching" (game not running) yields none of the
 // three dismiss signals (no live data, never "ready", never "blocked"), so the splash would hang


### PR DESCRIPTION
## Description

Electron 36 → 42 (shipped in 0.37.0) regressed transparent frameless windows on Windows — the opaque splash card composed as translucent and the desktop showed through. The splash code/CSS were **unchanged and correct**; the only variable was the Electron major bump.

This makes the splash window opaque (`transparent: false` + `backgroundColor: "#0d0e1a"`), restoring the intended solid card. The window transparency was only ever a trick to get rounded corners — the card itself was always meant to be opaque, and Win11 keeps native rounded corners.

> ⚠️ **Validate on a Windows RC** (`meter-2-build` with `pr=<this PR#>`): this is a runtime/Windows-only bug, not reproducible on macOS. Local gates (eslint, tsc, **620** vitest tests) pass.
> ⚠️ `linked issue` check will be red — creating the issue was blocked; admin-merge or add `Closes #N`.

## Key changes

- `createSplashWindow` in `app/src/main/index.ts`: `transparent: false` + opaque `backgroundColor`.
- Refreshed two stale splash comments (removed the long-gone "Pular" skip-button references).

## Screenshots

Pending the Windows RC — the transparent-window bug does not reproduce on macOS, so a local frame wouldn't be representative.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How was this tested?

- [x] `app/`: `pnpm check` and `pnpm test` pass (620 tests)
- [ ] Manually verified — PENDING: needs a Windows RC build

## Checklist

- [x] Conventional commit subjects
- [x] Self-reviewed the diff
- [x] No hand-edits to generated/synced files
- [x] No secrets committed