### PR TITLE
fix(app): don't sign out on a 403 run-signature rejection

### DIFF
--- a/app/src/main/__tests__/share-401.test.ts
+++ b/app/src/main/__tests__/share-401.test.ts
@@ -92,4 +92,23 @@ describe("uploadRun 401 -> clearSession", () => {
     expect(res.ok).toBe(false);
     expect(clearSession).not.toHaveBeenCalled();
   });
+
+  it("does NOT clear the session on a 403 (run-signature rejection, not auth)", async () => {
+    // The run-signature gate (REQUIRE_RUN_SIGNATURE) returns 403, not 401. A logged-in
+    // user with a valid token but a bad/clock-skewed/missing signature must stay signed
+    // in (the 2026-06-19 regression: a signature 401 signed users out). Surfacing the
+    // "forbidden" code lets auto-upload abort the cycle without dropping the session.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 403,
+        json: async () => ({ error: { code: "forbidden", message: "Request signature verification failed." } }),
+      })),
+    );
+    const res = await uploadRun(run());
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.code).toBe("forbidden");
+    expect(clearSession).not.toHaveBeenCalled();
+  });
 });

--- a/app/src/main/auto-upload.ts
+++ b/app/src/main/auto-upload.ts
@@ -176,6 +176,14 @@ async function runCycle(): Promise<void> {
         // signed-out gate above keeps subsequent ticks a no-op until sign-in.
         console.log("[auto-upload] aborting cycle: unauthorized");
         break;
+      } else if (result.code === "forbidden") {
+        // 403 = the run-signature gate rejected this upload (missing / clock-skewed /
+        // bad signature, or a key the API doesn't accept). NOT an auth failure, so the
+        // session stays intact (uploadRun never clearSession()s on 403). Every run this
+        // cycle would be rejected identically, so abort; the run is NOT marked failed —
+        // it retries next tick, where a clock resync or an app update can recover it.
+        console.log("[auto-upload] aborting cycle: signature rejected (403)");
+        break;
       } else if (result.code === "bad_request") {
         // Permanent per-run rejection: record it so we never retry it again.
         state.failed[run.id] = result.code;

--- a/app/src/main/share.ts
+++ b/app/src/main/share.ts
@@ -336,14 +336,17 @@ export async function uploadRun(run: RunRecord): Promise<ShareResult> {
 
   if (!res.ok) {
     const errBody = body as ApiErrorBody | null;
-    // 401 on an attributed upload = the JWT expired. There is no refresh token
-    // (the API mints a ~30d HS256 token, no refresh), so this is terminal for the
-    // session: clear it + broadcast "signed out" (same UX as a lost session). The
-    // run is NOT marked failed — it waits for the next sign-in to upload.
-    // (A 401 here is the EXPIRED-token case. The signature is always-on but the API
-    // ignores it until REQUIRE_RUN_SIGNATURE is enabled, so it cannot 401 us yet;
-    // once it does, a signature 401 is also terminal-for-this-attempt, which is fine —
-    // clearSession() only fires when we actually held a token, as here.)
+    // 401 = the JWT expired / session invalid. There is no refresh token (the API
+    // mints a ~30d HS256 token, no refresh), so this is terminal for the session:
+    // clear it + broadcast "signed out" (same UX as a lost session). The run is NOT
+    // marked failed — it waits for the next sign-in to upload.
+    //
+    // ONLY 401 clears the session. A run-signature rejection comes back as 403
+    // (signature.ts), NOT 401 — a bad/expired/clock-skewed signature on an
+    // otherwise-valid token must not sign the user out. (It used to: the API
+    // returned 401 for signature failures, so a logged-in meter went OFFLINE the
+    // moment a signature tripped — the 2026-06-19 regression. 403 is handled below
+    // by auto-upload as terminal-for-this-attempt, with the session left intact.)
     if (res.status === 401) {
       clearSession();
     }


### PR DESCRIPTION
## What

`uploadRun` clears the session (`clearSession()`) only on a **401**. As of `mad-labs-org/tbh-wiki#435` the run-signature gate returns **403**, so a signature rejection now leaves the session intact. `auto-upload` aborts the cycle on a `forbidden` result without marking the run failed (it retries next tick).

## Why

When `REQUIRE_RUN_SIGNATURE` was enabled on 2026-06-19, the gate's rejection came back as 401 and the meter treated it as an expired token → signed the user out → **OFFLINE**, even with a perfectly valid Discord session. Multiple players: "says connected, but stays offline after updating." A bad/clock-skewed/missing signature is not an auth failure and must not drop the session.

## Changes
- `app/src/main/share.ts` — corrected the misleading comment; `clearSession()` stays 401-only (now correct against the 403 from the API).
- `app/src/main/auto-upload.ts` — explicit `forbidden` (403) branch: abort the cycle, don't mark failed, don't clear the session.
- `app/src/main/__tests__/share-401.test.ts` — regression test: a 403 does **not** clear the session and surfaces `code: "forbidden"`.

## Verify
`pnpm check` clean; `share-401` + `auto-upload` suites pass (9 tests).

## Depends on
`mad-labs-org/tbh-wiki#435` (API returning 403). Order for re-enabling the gate: deploy #435 → fleet on a signed build → re-enable `REQUIRE_RUN_SIGNATURE`.

Closes #44