### PR TITLE
fix(app): stop the live team hero tooltip from flickering

### DIFF
--- a/app/src/renderer/src/components/HeroFrame.tsx
+++ b/app/src/renderer/src/components/HeroFrame.tsx
@@ -104,7 +104,10 @@ export function HeroFrame({
       )}
 
       {(progress || info) && (
-        <OverlayTooltip anchorRef={anchorRef} open={open}>
+        // placement="top": this frame lives in the overlay's bottom footer, so the card opens the
+        // tooltip UPWARD — a downward one would grow the window under the cursor and flicker (see
+        // OverlayTooltip).
+        <OverlayTooltip anchorRef={anchorRef} open={open} placement="top">
           <div className="flex min-w-[8.5rem] flex-col gap-2">
             <div className="flex items-center justify-between gap-3 border-b border-surface-600/70 pb-1">
               <span className="font-mono text-[10px] font-bold uppercase tracking-wider text-zinc-200">

--- a/app/src/renderer/src/components/OverlayTooltip.tsx
+++ b/app/src/renderer/src/components/OverlayTooltip.tsx
@@ -5,10 +5,18 @@ import { nextExtentId, setOverlayExtent, clearOverlayExtent } from "~/lib/overla
 
 // A real floating tooltip for the height-pinned, transparent overlay window. It must NOT be a
 // descendant of the meter card: the card's backdrop-filter creates a containing block that clips
-// position:fixed — so this portals to document.body. It positions itself just under `anchorRef`,
-// clamps to the window width, and reports its bottom edge via the overlay-extent so the window grows
-// (in transparent space) instead of clipping it. pointer-events-none: a plain tooltip, never grabs
-// the mouse. Shared by the stage-threat badges and the per-hero resistance frames.
+// position:fixed — so this portals to document.body. It positions itself just under `anchorRef`
+// (or just ABOVE it when placement="top"), clamps to the window width, and reports its bottom edge
+// via the overlay-extent so the window grows (in transparent space) instead of clipping it.
+// pointer-events-none: a plain tooltip, never grabs the mouse. Shared by the stage-threat badges and
+// the per-hero resistance frames.
+//
+// placement="top" exists for anchors at the window's BOTTOM edge (the per-hero footer frames): a
+// downward tooltip there would push past the card and GROW the window — and resizing a transparent
+// frameless window under a stationary cursor makes Chromium fire a phantom mouseleave on the anchor,
+// which closes the tooltip → shrinks the window → fires mouseenter → reopens → … a self-sustaining
+// blink. Opening UPWARD over the existing card needs no window growth, so the cursor is never
+// disturbed and the tooltip holds steady.
 
 const EDGE_PAD = 4;
 const GAP = 6;
@@ -18,15 +26,18 @@ export function OverlayTooltip({
   open,
   children,
   className,
+  placement = "bottom",
 }: {
   anchorRef: React.RefObject<HTMLElement | null>;
   open: boolean;
   children: React.ReactNode;
   className?: string;
+  /** "bottom" (default) opens below the anchor; "top" opens above it (no window growth). */
+  placement?: "top" | "bottom";
 }) {
   if (!open) return null;
   return createPortal(
-    <TipBox anchorRef={anchorRef} className={className}>
+    <TipBox anchorRef={anchorRef} className={className} placement={placement}>
       {children}
     </TipBox>,
     document.body,
@@ -37,10 +48,12 @@ function TipBox({
   anchorRef,
   children,
   className,
+  placement,
 }: {
   anchorRef: React.RefObject<HTMLElement | null>;
   children: React.ReactNode;
   className?: string;
+  placement: "top" | "bottom";
 }) {
   const boxRef = useRef<HTMLDivElement>(null);
   const idRef = useRef<number>(nextExtentId());
@@ -56,9 +69,17 @@ function TipBox({
         EDGE_PAD,
         Math.min(anchor.left, window.innerWidth - box.width - EDGE_PAD),
       );
-      const top = anchor.bottom + GAP;
+      // "top" sits the tooltip's BOTTOM a GAP above the anchor (clamped into view); "bottom" drops
+      // it a GAP below.
+      const top =
+        placement === "top"
+          ? Math.max(EDGE_PAD, anchor.top - GAP - box.height)
+          : anchor.bottom + GAP;
       setPos((p) => (p && p.top === top && p.left === left ? p : { top, left }));
-      setOverlayExtent(id, top + box.height + EDGE_PAD);
+      // "bottom" reports its bottom edge so the window GROWS instead of clipping it. "top" opens
+      // over the existing card and must NEVER grow the window — a resize under the cursor is what
+      // makes the footer tooltip flicker — so it contributes no extent at all.
+      setOverlayExtent(id, placement === "top" ? 0 : top + box.height + EDGE_PAD);
     };
     place();
     const ro = new ResizeObserver(place);
@@ -70,7 +91,7 @@ function TipBox({
       clearOverlayExtent(id);
     };
     // children in deps: re-place when the tooltip's content (size) changes.
-  }, [anchorRef, children]);
+  }, [anchorRef, children, placement]);
 
   return (
     <div


### PR DESCRIPTION
## Description

Hovering a hero sprite in the live overlay's **Team** footer made its tooltip flicker continuously, even with the mouse held still. The footer sits at the overlay's bottom edge, so the tooltip opened *downward* and grew the height-pinned transparent window to fit. Resizing a frameless transparent window **under a stationary cursor** makes Chromium fire a phantom `mouseleave` on the anchor → the tooltip closes → the window shrinks → that fires `mouseenter` → it reopens → grows again → a self-sustaining blink. (The StageThreat badges never flickered because they live at the top of the card, where the tooltip fits inside the window with no resize — same `useHoverTooltip`/`OverlayTooltip` code, different position.)

Fix: open the hero tooltip **upward** over the existing card so the window never resizes on hover, removing the trigger entirely.

## Key changes

- `OverlayTooltip`: new `placement?: "top" | "bottom"` (default `"bottom"`, unchanged for StageThreat). A `"top"` tooltip sits its bottom a gap above the anchor and contributes **zero** overlay-extent, so it can never grow the window.
- `HeroFrame`: renders its tooltip with `placement="top"`.

## Screenshots

**Before** — tooltip opened below the footer, growing the window under the cursor (the flicker source):

![before](https://github.com/mad-labs-org/tbh-meter/raw/7c2635729280b404889e98be647c0367018a0acb/hero-tooltip-flicker/before-below.png)

**After** — tooltip opens above, over the card; window height is unchanged on hover, so it holds steady:

![after](https://github.com/mad-labs-org/tbh-meter/raw/7c2635729280b404889e98be647c0367018a0acb/hero-tooltip-flicker/after-above.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor / chore / docs (no user-visible behavior change)

## How was this tested?

- [x] `app/`: `pnpm check` and `pnpm test` pass (721 tests)
- [ ] `reader/`: `ruff check .` and `pytest` pass
- [x] Manually verified in the running app — CDP-measured overlay window height is constant (333px) idle → hover → after (no growth), and the live flicker is gone (confirmed on the macOS dev overlay)

## Checklist

- [x] Conventional commit subjects — they drive the computed release version and the changelog
- [x] Self-reviewed the diff
- [x] No hand-edits to generated/synced files (`app/src/shared/data/`, `app/src/renderer/public/{sprites,heroes}/`)
- [x] No secrets committed