### PR TITLE
fix(app): surface involuntary 401 logout instead of silent sign-out

### DIFF
--- a/app/src/main/__tests__/auth.test.ts
+++ b/app/src/main/__tests__/auth.test.ts
@@ -14,6 +14,11 @@ vi.mock("electron", () => ({
   BrowserWindow: { getAllWindows: () => [] },
 }));
 
+// Spy on the renderer fan-out so we can assert clearSession("expired") emits the
+// involuntary-logout signal (and a plain sign-out does not).
+const broadcast = vi.fn();
+vi.mock("../broadcast.js", () => ({ broadcast: (...args: unknown[]) => broadcast(...args) }));
+
 const sessionPath = join(dir, "auth-session.json");
 
 afterAll(() => {
@@ -29,6 +34,7 @@ async function freshAuth() {
 
 beforeEach(() => {
   rmSync(sessionPath, { force: true });
+  broadcast.mockClear();
 });
 
 // --------------------------------------------------------------------------- //
@@ -135,6 +141,26 @@ describe("clearSession / clearSessionFile", () => {
     expect(existsSync(sessionPath)).toBe(false); // persisted removal
     expect(await auth.getAccessToken()).toBeNull();
     expect(await auth.getStatus()).toEqual({ signedIn: false });
+  });
+
+  it("clearSession('expired') emits meter:session-expired (involuntary 401 logout)", async () => {
+    writeFileSync(sessionPath, JSON.stringify({ accessToken: "tok-xyz" }), "utf-8");
+    const auth = await freshAuth();
+    await auth.getAccessToken(); // force load so clearSession has a session to clear
+
+    auth.clearSession("expired");
+
+    expect(broadcast).toHaveBeenCalledWith("meter:session-expired");
+  });
+
+  it("clearSession() (manual sign-out) does NOT emit meter:session-expired", async () => {
+    writeFileSync(sessionPath, JSON.stringify({ accessToken: "tok-xyz" }), "utf-8");
+    const auth = await freshAuth();
+    await auth.getAccessToken();
+
+    auth.clearSession();
+
+    expect(broadcast).not.toHaveBeenCalledWith("meter:session-expired");
   });
 
   it("clearSessionFile removes the file even before the session was loaded", async () => {

--- a/app/src/main/__tests__/share-401.test.ts
+++ b/app/src/main/__tests__/share-401.test.ts
@@ -14,12 +14,17 @@ vi.mock("electron", () => ({
 const clearSession = vi.fn();
 vi.mock("../auth.js", () => ({
   getAccessToken: async () => "bearer-token",
-  clearSession: () => clearSession(),
+  // Forward the reason arg so the test can assert "expired" vs "manual".
+  clearSession: (reason?: string) => clearSession(reason),
 }));
 vi.mock("../settings.js", () => ({ getSettings: () => ({}) }));
 vi.mock("../device-id.js", () => ({ getDeviceId: () => "device-uuid" }));
 vi.mock("../runs-store.js", () => ({ getRun: () => null }));
-vi.mock("../error-report.js", () => ({ reportError: () => {}, describeCause: () => ({}) }));
+const reportError = vi.fn();
+vi.mock("../error-report.js", () => ({
+  reportError: (...args: unknown[]) => reportError(...args),
+  describeCause: () => ({}),
+}));
 // uploadRun posts via httpFetch (Electron net) — delegate to the stubbed global fetch.
 vi.mock("../net-fetch.js", () => ({
   httpFetch: (input: string | GlobalRequest, init?: RequestInit) => fetch(input, init),
@@ -72,6 +77,7 @@ function mockFetchStatus(status: number): void {
 
 beforeEach(() => {
   clearSession.mockClear();
+  reportError.mockClear();
 });
 
 afterEach(() => {
@@ -79,11 +85,24 @@ afterEach(() => {
 });
 
 describe("uploadRun 401 -> clearSession", () => {
-  it("clears the session on a 401 (expired token, no refresh)", async () => {
+  it("clears the session as 'expired' on a 401 (expired token, no refresh)", async () => {
     mockFetchStatus(401);
     const res = await uploadRun(run());
     expect(res.ok).toBe(false);
     expect(clearSession).toHaveBeenCalledTimes(1);
+    // "expired" (not "manual") so the renderer prompts a re-sign-in instead of
+    // going silently offline.
+    expect(clearSession).toHaveBeenCalledWith("expired");
+  });
+
+  it("pings session-expired telemetry on a 401 (the 401 is suppressed from the upload-failed relay)", async () => {
+    mockFetchStatus(401);
+    await uploadRun(run());
+    expect(reportError).toHaveBeenCalledWith(
+      "auth:session-expired",
+      expect.any(String),
+      expect.objectContaining({ status: 401 }),
+    );
   });
 
   it("does NOT clear the session on a non-401 4xx (a payload rejection)", async () => {

--- a/app/src/main/auth.ts
+++ b/app/src/main/auth.ts
@@ -201,13 +201,26 @@ export function getAccessToken(): Promise<string | null> {
   return Promise.resolve(loadSession()?.accessToken ?? null);
 }
 
-/** Clear the stored session + broadcast "signed out". Called on explicit sign-out
- *  and when the API rejects the bearer with 401 (the token expired — no refresh). */
-export function clearSession(): void {
+/**
+ * Clear the stored session + broadcast "signed out".
+ *
+ * `reason` distinguishes the two callers so the renderer can react differently:
+ *   - "manual" (default): the user pressed Sign out — a deliberate, expected state.
+ *   - "expired": the API rejected the bearer with 401 (the ~30-day HS256 token
+ *     expired OR the server's JWT_SECRET was rotated — there is no refresh token).
+ *     The user was signed in a moment ago and is being kicked involuntarily, so we
+ *     additionally emit `meter:session-expired` for the renderer to surface a clear
+ *     "sign in again" prompt instead of silently dropping to OFFLINE. The silent
+ *     logout was invisible to the user AND to us (401 upload failures are suppressed
+ *     from the error relay — see share.ts isReportableUploadFailure), which is why a
+ *     JWT_SECRET rotation only surfaced via player DMs.
+ */
+export function clearSession(reason: "manual" | "expired" = "manual"): void {
   if (!loadSession()) return;
   session = null;
   persistSession();
   broadcastStatus();
+  if (reason === "expired") broadcast("meter:session-expired");
 }
 
 export function signOut(): Promise<void> {

--- a/app/src/main/share.ts
+++ b/app/src/main/share.ts
@@ -51,6 +51,16 @@ export function isReportableUploadFailure(status: number): boolean {
   return status < 500 && status !== 401 && status !== 408 && status !== 429;
 }
 
+// Telemetry for the involuntary-logout (401) path. 401 is deliberately suppressed
+// from the upload-failed relay above (it is self-healing for noise purposes), so
+// without an explicit ping a JWT_SECRET rotation or mass token expiry is INVISIBLE
+// to us — the 2026-06 incident only surfaced via player DMs. error-report dedups per
+// (context, message) per session, so keeping these identical at both 401 sites makes
+// the ping fire AT MOST ONCE per session: a fleet logout-rate signal, not 401 noise.
+const SESSION_EXPIRED_CONTEXT = "auth:session-expired";
+const SESSION_EXPIRED_MESSAGE =
+  "Bearer JWT rejected (401) — session cleared; user must re-sign-in (no refresh token).";
+
 interface UploadEntry {
   id: string;
   url: string;
@@ -338,8 +348,10 @@ export async function uploadRun(run: RunRecord): Promise<ShareResult> {
     const errBody = body as ApiErrorBody | null;
     // 401 = the JWT expired / session invalid. There is no refresh token (the API
     // mints a ~30d HS256 token, no refresh), so this is terminal for the session:
-    // clear it + broadcast "signed out" (same UX as a lost session). The run is NOT
-    // marked failed — it waits for the next sign-in to upload.
+    // clear it as "expired" (broadcasts meter:session-expired so the renderer prompts
+    // a re-sign-in instead of going silently OFFLINE) + ping telemetry (the 401 is
+    // suppressed from the relay below). The run is NOT marked failed — it stays queued
+    // and uploads on the next sign-in.
     //
     // ONLY 401 clears the session. A run-signature rejection comes back as 403
     // (signature.ts), NOT 401 — a bad/expired/clock-skewed signature on an
@@ -348,7 +360,11 @@ export async function uploadRun(run: RunRecord): Promise<ShareResult> {
     // moment a signature tripped — the 2026-06-19 regression. 403 is handled below
     // by auto-upload as terminal-for-this-attempt, with the session left intact.)
     if (res.status === 401) {
-      clearSession();
+      clearSession("expired");
+      reportError(SESSION_EXPIRED_CONTEXT, SESSION_EXPIRED_MESSAGE, {
+        externalId: payload.externalId,
+        status: 401,
+      });
     }
     // Relay only actionable (client-side) failures; transient/infra ones are
     // already retried by auto-upload and would just be noise. See helper.
@@ -415,8 +431,13 @@ export async function claimDeviceRuns(): Promise<void> {
       const data = (await res.json().catch(() => null)) as { claimed?: number } | null;
       if (data?.claimed) console.log(`[share] claimed ${data.claimed} anonymous run(s)`);
     } else {
-      // 401 = the JWT expired (no refresh token). Treat the session as gone.
-      if (res.status === 401) clearSession();
+      // 401 = the JWT was rejected (expired, or JWT_SECRET rotated — no refresh
+      // token). Treat the session as gone, surface it (claim runs at startup, so this
+      // is often the FIRST path to detect a dead restored token), and ping telemetry.
+      if (res.status === 401) {
+        clearSession("expired");
+        reportError(SESSION_EXPIRED_CONTEXT, SESSION_EXPIRED_MESSAGE, { phase: "claim" });
+      }
       console.warn(`[share] claim failed (HTTP ${res.status})`);
     }
   } catch (err) {

--- a/app/src/preload/index.ts
+++ b/app/src/preload/index.ts
@@ -104,6 +104,12 @@ const meter: MeterApi = {
     return () => ipcRenderer.off("meter:auth-changed", listener);
   },
 
+  onSessionExpired: (cb) => {
+    const listener = (): void => cb();
+    ipcRenderer.on("meter:session-expired", listener);
+    return () => ipcRenderer.off("meter:session-expired", listener);
+  },
+
   shareRun: (runId) => ipcRenderer.invoke("meter:share-run", runId),
   getShareStatus: (runId) => ipcRenderer.invoke("meter:get-share-status", runId),
 

--- a/app/src/renderer/src/components/SignInPromptModal.tsx
+++ b/app/src/renderer/src/components/SignInPromptModal.tsx
@@ -5,15 +5,23 @@ import { DiscordIcon } from "~/components/DiscordIcon";
 import { useT } from "~/lib/i18n";
 
 /**
- * Shown when the runs window opens while signed OUT (unless the user opted out):
- * runs are saved locally either way, but they only reach the leaderboard when
- * signed in. Closes itself the moment auth flips to signed in.
+ * Two modes, one modal:
+ *   - the gentle first-run nudge: shown when the runs window opens while signed OUT
+ *     (unless the user opted out via hideSignInPrompt); runs are saved locally either
+ *     way but only reach the leaderboard when signed in.
+ *   - the involuntary-expiry notice (`expired`): a 401 cleared the session out from
+ *     under a signed-in user (token expired / JWT_SECRET rotated — no refresh). It is
+ *     forced open by `meter:session-expired` REGARDLESS of the opt-out, with explicit
+ *     "your session expired, sign in again" copy, so the user knows their runs stopped
+ *     syncing instead of silently going OFFLINE.
+ * Closes itself the moment auth flips to signed in.
  */
 export function SignInPromptModal() {
   const t = useT();
   const [open, setOpen] = useState(false);
   const [signingIn, setSigningIn] = useState(false);
   const [dontShowAgain, setDontShowAgain] = useState(false);
+  const [expired, setExpired] = useState(false);
 
   useEffect(() => {
     Promise.all([window.meter.authGetStatus(), window.meter.getSettings()])
@@ -21,16 +29,34 @@ export function SignInPromptModal() {
         if (!auth.signedIn && !settings.hideSignInPrompt) setOpen(true);
       })
       .catch(() => setOpen(false));
-    return window.meter.onAuthChanged((auth) => {
-      if (auth.signedIn) setOpen(false);
+
+    const offAuth = window.meter.onAuthChanged((auth) => {
+      // A successful (re-)sign-in resolves both the nudge and the expiry notice.
+      if (auth.signedIn) {
+        setOpen(false);
+        setExpired(false);
+      }
       setSigningIn(false);
     });
+    // Involuntary 401 logout: force the prompt open with the expiry copy. This ignores
+    // hideSignInPrompt on purpose — that opt-out silences the first-run nudge, never a
+    // logout the user did not ask for.
+    const offExpired = window.meter.onSessionExpired(() => {
+      setExpired(true);
+      setOpen(true);
+    });
+    return () => {
+      offAuth();
+      offExpired();
+    };
   }, []);
 
   if (!open) return null;
 
   const dismiss = (): void => {
-    if (dontShowAgain) void window.meter.setSettings({ hideSignInPrompt: true });
+    // Only the gentle nudge is opt-out-able; an expiry notice must never persist
+    // hideSignInPrompt (that would suppress future involuntary-logout notices too).
+    if (!expired && dontShowAgain) void window.meter.setSettings({ hideSignInPrompt: true });
     setOpen(false);
   };
 
@@ -40,18 +66,22 @@ export function SignInPromptModal() {
   };
 
   return (
-    <Modal title={t("signin.title")} onClose={dismiss}>
-      <p className="mt-2 text-xs text-zinc-400">{t("signin.body")}</p>
+    <Modal title={expired ? t("signin.expiredTitle") : t("signin.title")} onClose={dismiss}>
+      <p className="mt-2 text-xs text-zinc-400">{expired ? t("signin.expiredBody") : t("signin.body")}</p>
       <div className="mt-4 flex items-center justify-between gap-2">
-        <label className="flex cursor-pointer items-center gap-1.5 text-[11px] text-zinc-500">
-          <input
-            type="checkbox"
-            checked={dontShowAgain}
-            onChange={(e) => setDontShowAgain(e.target.checked)}
-            className="size-3 cursor-pointer accent-brand-500"
-          />
-          {t("signin.dontShow")}
-        </label>
+        {expired ? (
+          <span />
+        ) : (
+          <label className="flex cursor-pointer items-center gap-1.5 text-[11px] text-zinc-500">
+            <input
+              type="checkbox"
+              checked={dontShowAgain}
+              onChange={(e) => setDontShowAgain(e.target.checked)}
+              className="size-3 cursor-pointer accent-brand-500"
+            />
+            {t("signin.dontShow")}
+          </label>
+        )}
         <div className="flex items-center gap-2">
           <button
             onClick={dismiss}

--- a/app/src/shared/i18n/de-de.ts
+++ b/app/src/shared/i18n/de-de.ts
@@ -292,6 +292,9 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "signin.dontShow": "Nicht mehr anzeigen",
   "signin.notNow": "Jetzt nicht",
 
+  "signin.expiredTitle": "Deine Sitzung ist abgelaufen",
+  "signin.expiredBody":
+    "Du wurdest abgemeldet, daher werden deine Runs nicht mehr mit der Bestenliste synchronisiert. Sie werden lokal gespeichert. Melde dich erneut an, um fortzufahren.",
   // ── Tray menu ──
   "tray.showLive": "Live-Meter zeigen",
   "tray.openRuns": "Runs öffnen",

--- a/app/src/shared/i18n/en-us.ts
+++ b/app/src/shared/i18n/en-us.ts
@@ -298,6 +298,9 @@ export const DICT = {
   "signin.dontShow": "Don't show this again",
   "signin.notNow": "Not now",
 
+  "signin.expiredTitle": "Your session expired",
+  "signin.expiredBody":
+    "You were signed out, so your runs stopped syncing to the leaderboard. They're saved locally. Sign in again to resume.",
   // ── Tray menu ──
   "tray.showLive": "Show live meter",
   "tray.openRuns": "Open runs",

--- a/app/src/shared/i18n/es-es.ts
+++ b/app/src/shared/i18n/es-es.ts
@@ -292,6 +292,9 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "signin.dontShow": "No volver a mostrar",
   "signin.notNow": "Ahora no",
 
+  "signin.expiredTitle": "Tu sesión ha caducado",
+  "signin.expiredBody":
+    "Se cerró tu sesión, así que tus runs dejaron de sincronizarse con la clasificación. Se guardan localmente. Inicia sesión de nuevo para reanudar.",
   // ── Tray menu ──
   "tray.showLive": "Mostrar live meter",
   "tray.openRuns": "Abrir runs",

--- a/app/src/shared/i18n/fr-fr.ts
+++ b/app/src/shared/i18n/fr-fr.ts
@@ -291,6 +291,9 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "signin.dontShow": "Ne plus afficher",
   "signin.notNow": "Pas maintenant",
 
+  "signin.expiredTitle": "Votre session a expiré",
+  "signin.expiredBody":
+    "Vous avez été déconnecté, donc vos runs ne se synchronisent plus avec le classement. Elles sont enregistrées localement. Reconnectez-vous pour reprendre.",
   // ── Tray menu ──
   "tray.showLive": "Afficher le live meter",
   "tray.openRuns": "Ouvrir les runs",

--- a/app/src/shared/i18n/id-id.ts
+++ b/app/src/shared/i18n/id-id.ts
@@ -291,6 +291,9 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "signin.dontShow": "Jangan tampilkan lagi",
   "signin.notNow": "Nanti saja",
 
+  "signin.expiredTitle": "Sesimu telah berakhir",
+  "signin.expiredBody":
+    "Kamu keluar, jadi run-mu berhenti tersinkron ke papan peringkat. Run tetap tersimpan lokal. Masuk lagi untuk melanjutkan.",
   // ── Tray menu ──
   "tray.showLive": "Tampilkan live meter",
   "tray.openRuns": "Buka run",

--- a/app/src/shared/i18n/ja-jp.ts
+++ b/app/src/shared/i18n/ja-jp.ts
@@ -291,6 +291,9 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "signin.dontShow": "今後表示しない",
   "signin.notNow": "あとで",
 
+  "signin.expiredTitle": "セッションの有効期限が切れました",
+  "signin.expiredBody":
+    "サインアウトされたため、ランがリーダーボードへの同期を停止しました。ランはローカルに保存されています。再度サインインすると同期を再開します。",
   // ── Tray menu ──
   "tray.showLive": "ライブメーターを表示",
   "tray.openRuns": "ラン一覧を開く",

--- a/app/src/shared/i18n/ko-kr.ts
+++ b/app/src/shared/i18n/ko-kr.ts
@@ -289,6 +289,9 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "signin.dontShow": "다시 표시하지 않기",
   "signin.notNow": "나중에",
 
+  "signin.expiredTitle": "세션이 만료되었습니다",
+  "signin.expiredBody":
+    "로그아웃되어 런이 리더보드 동기화를 멈췄습니다. 런은 로컬에 저장됩니다. 다시 로그인하면 동기화를 재개합니다.",
   // ── Tray menu ──
   "tray.showLive": "라이브 미터 표시",
   "tray.openRuns": "런 목록 열기",

--- a/app/src/shared/i18n/pl-pl.ts
+++ b/app/src/shared/i18n/pl-pl.ts
@@ -292,6 +292,9 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "signin.dontShow": "Nie pokazuj ponownie",
   "signin.notNow": "Nie teraz",
 
+  "signin.expiredTitle": "Twoja sesja wygasła",
+  "signin.expiredBody":
+    "Zostałeś wylogowany, więc twoje przejścia przestały synchronizować się z rankingiem. Są zapisywane lokalnie. Zaloguj się ponownie, aby wznowić.",
   // ── Tray menu ──
   "tray.showLive": "Pokaż live meter",
   "tray.openRuns": "Otwórz przejścia",

--- a/app/src/shared/i18n/pt-br.ts
+++ b/app/src/shared/i18n/pt-br.ts
@@ -291,6 +291,9 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "signin.dontShow": "Não mostrar de novo",
   "signin.notNow": "Agora não",
 
+  "signin.expiredTitle": "Sua sessão expirou",
+  "signin.expiredBody":
+    "Você foi desconectado, então suas runs pararam de sincronizar com o ranking. Elas ficam salvas localmente. Entre de novo para retomar.",
   // ── Tray menu ──
   "tray.showLive": "Mostrar live meter",
   "tray.openRuns": "Abrir runs",

--- a/app/src/shared/i18n/ru-ru.ts
+++ b/app/src/shared/i18n/ru-ru.ts
@@ -291,6 +291,9 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "signin.dontShow": "Больше не показывать",
   "signin.notNow": "Не сейчас",
 
+  "signin.expiredTitle": "Ваша сессия истекла",
+  "signin.expiredBody":
+    "Вы вышли из аккаунта, поэтому ваши забеги перестали синхронизироваться с таблицей лидеров. Они сохраняются локально. Войдите снова, чтобы продолжить.",
   // ── Tray menu ──
   "tray.showLive": "Показать live-метер",
   "tray.openRuns": "Открыть забеги",

--- a/app/src/shared/i18n/th-th.ts
+++ b/app/src/shared/i18n/th-th.ts
@@ -289,6 +289,9 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "signin.dontShow": "ไม่ต้องแสดงอีก",
   "signin.notNow": "ยังก่อน",
 
+  "signin.expiredTitle": "เซสชันของคุณหมดอายุ",
+  "signin.expiredBody":
+    "คุณถูกออกจากระบบ รันของคุณจึงหยุดซิงค์กับลีดเดอร์บอร์ด รันยังถูกบันทึกไว้ในเครื่อง เข้าสู่ระบบอีกครั้งเพื่อซิงค์ต่อ",
   // ── Tray menu ──
   "tray.showLive": "แสดง live meter",
   "tray.openRuns": "เปิดรายการรัน",

--- a/app/src/shared/i18n/tr-tr.ts
+++ b/app/src/shared/i18n/tr-tr.ts
@@ -292,6 +292,9 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "signin.dontShow": "Bir daha gösterme",
   "signin.notNow": "Şimdi değil",
 
+  "signin.expiredTitle": "Oturumun sona erdi",
+  "signin.expiredBody":
+    "Çıkış yapıldı, bu yüzden runların lider tablosuna senkronlanmayı durdurdu. Yerel olarak kaydediliyorlar. Devam etmek için tekrar giriş yap.",
   // ── Tray menu ──
   "tray.showLive": "Canlı meter'i göster",
   "tray.openRuns": "Runları aç",

--- a/app/src/shared/i18n/uk-ua.ts
+++ b/app/src/shared/i18n/uk-ua.ts
@@ -292,6 +292,9 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "signin.dontShow": "Більше не показувати",
   "signin.notNow": "Не зараз",
 
+  "signin.expiredTitle": "Ваша сесія завершилася",
+  "signin.expiredBody":
+    "Ви вийшли з облікового запису, тож ваші забіги перестали синхронізуватися з таблицею лідерів. Вони зберігаються локально. Увійдіть знову, щоб продовжити.",
   // ── Tray menu ──
   "tray.showLive": "Показати live-метер",
   "tray.openRuns": "Відкрити забіги",

--- a/app/src/shared/i18n/vi-vn.ts
+++ b/app/src/shared/i18n/vi-vn.ts
@@ -292,6 +292,9 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "signin.dontShow": "Đừng hiện lại",
   "signin.notNow": "Để sau",
 
+  "signin.expiredTitle": "Phiên của bạn đã hết hạn",
+  "signin.expiredBody":
+    "Bạn đã bị đăng xuất, nên lượt chơi của bạn ngừng đồng bộ lên bảng xếp hạng. Chúng vẫn được lưu cục bộ. Đăng nhập lại để tiếp tục.",
   // ── Tray menu ──
   "tray.showLive": "Hiện live meter",
   "tray.openRuns": "Mở lượt chơi",

--- a/app/src/shared/i18n/zh-hans.ts
+++ b/app/src/shared/i18n/zh-hans.ts
@@ -285,6 +285,9 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "signin.dontShow": "不再显示",
   "signin.notNow": "暂不",
 
+  "signin.expiredTitle": "你的登录已过期",
+  "signin.expiredBody":
+    "你已退出登录，挑战因此停止同步到排行榜。挑战仍保存在本地。重新登录即可继续同步。",
   // ── Tray menu ──
   "tray.showLive": "显示实时悬浮窗",
   "tray.openRuns": "打开挑战列表",

--- a/app/src/shared/i18n/zh-hant.ts
+++ b/app/src/shared/i18n/zh-hant.ts
@@ -285,6 +285,9 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "signin.dontShow": "不再顯示",
   "signin.notNow": "暫不",
 
+  "signin.expiredTitle": "你的登入已過期",
+  "signin.expiredBody":
+    "你已登出，挑戰因此停止同步到排行榜。挑戰仍儲存在本機。重新登入即可繼續同步。",
   // ── Tray menu ──
   "tray.showLive": "顯示即時懸浮窗",
   "tray.openRuns": "開啟挑戰清單",

--- a/app/src/shared/ipc-types.ts
+++ b/app/src/shared/ipc-types.ts
@@ -148,6 +148,10 @@ export interface MeterApi {
   authSignOut(): Promise<void>;
   /** Subscribe to auth changes (sign-in/out, token refresh). Returns an unsubscribe fn. */
   onAuthChanged(cb: (status: AuthStatus) => void): () => void;
+  /** Fired when the session was cleared involuntarily by a 401 (expired/rotated token,
+   *  no refresh) — distinct from a deliberate sign-out, so the UI can prompt a re-sign-in
+   *  instead of going silently offline. Returns an unsubscribe fn. */
+  onSessionExpired(cb: () => void): () => void;
   /** Share a successful run to the leaderboard; returns a discriminated result. */
   shareRun(runId: string): Promise<ShareResult>;
   /** Whether a run was already shared (and its public URL, if so). */


### PR DESCRIPTION
Closes #58

## Why

Players reported the meter **resetting its session on its own and not uploading runs**. Root cause (confirmed): the server's `JWT_SECRET` was rotated after the own-auth rollout, so meter clients that signed in **before** the rotation hold a token signed with the old secret. Their next `POST /runs` gets a genuine **401** → the meter clears the session.

That part is correct (there's no refresh token). The **bug is the UX**: the logout was *silent*.

- The user was dropped to OFFLINE with no explanation — they didn't know to sign in again, and their runs silently stopped reaching the leaderboard (they stay queued locally, but nothing said so).
- 401 is deliberately suppressed from the `/meter-errors` relay, so the logout was **invisible to us too** — this whole class of event only surfaced via player DMs.

This is the same `401 → clearSession` path as the 2026-06-19 incident; the signature side of that was already fixed (signature failures now return 403). This PR hardens the remaining genuine-401 path.

## What changed

- **`main/auth.ts`** — `clearSession(reason: "manual" | "expired")`. On `"expired"` it additionally broadcasts `meter:session-expired`. A deliberate sign-out stays `"manual"` and is unaffected.
- **`main/share.ts`** — the 401 branch in `uploadRun` **and** `claimDeviceRuns` now calls `clearSession("expired")` and fires a **deduped `auth:session-expired` telemetry ping** (once per session, distinct from the suppressed 401 upload noise) so fleet logout rate becomes observable.
- **`preload` + `shared/ipc-types.ts`** — new `onSessionExpired(cb)` bridge.
- **`renderer/SignInPromptModal.tsx`** — on the event, opens with explicit *"Your session expired — sign in again"* copy, **ignoring** the `hideSignInPrompt` opt-out (that opt-out only silences the first-run nudge, never an involuntary logout). Closes on successful re-sign-in.
- **i18n** — `signin.expiredTitle` / `signin.expiredBody` added to **all 16 locales**.
- **tests** — cover the `"expired"` broadcast (`auth.test.ts`) and the telemetry ping + `clearSession("expired")` arg (`share-401.test.ts`).

## User impact

Affected users still need to **sign in again once** (their old token is dead) — but now they're *told* to, instead of silently going offline. New sign-ins mint a token under the current secret and are fine.

## Verification

- `pnpm check` (eslint + tsc node + web): **clean**
- `pnpm test`: new tests pass; i18n completeness + placeholder guards pass.
  - ⚠️ One **pre-existing, unrelated** failure (`error-report.test.ts` cause-capture) reproduces on a clean `main` checkout in this environment (Node 22) — not touched by this PR.

> Note: the involuntary-logout prompt renders in the runs/list window (where `SignInPromptModal` mounts). If only the live overlay is open, it still flips to "Not syncing"; a tray/native notification could be a follow-up for full coverage.