### PR TITLE
feat(app): show seconds in timestamps

### DIFF
--- a/app/src/renderer/src/lib/format.ts
+++ b/app/src/renderer/src/lib/format.ts
@@ -202,7 +202,7 @@ export function ago(tsMs: number, t: Translate = tEn): string {
   return t("ago.y", { n: Math.floor(days / 365) });
 }
 
-/** Absolute local date+time in short style. `lang` (BCP47, from useI18n) follows the app
+/** Absolute local date+time: short date, medium time (includes seconds). `lang` (BCP47, from useI18n) follows the app
  *  language; undefined falls back to the OS locale's conventions (DD/MM vs MM/DD, 12/24h).
  *  Takes an epoch in MILLISECONDS (Redesign 2: run ts is ms; loadStructured normalizes
  *  legacy seconds -> ms). */
@@ -210,6 +210,6 @@ export function formatDateTime(tsMs: number, lang?: string): string {
   if (!Number.isFinite(tsMs) || tsMs <= 0) return "";
   return new Date(tsMs).toLocaleString(lang, {
     dateStyle: "short",
-    timeStyle: "short",
+    timeStyle: "medium",
   });
 }


### PR DESCRIPTION
## Description

Run timestamps in the meter (runs list and run detail) were shown down to the minute only (`6/23/26, 2:32 PM`). This adds seconds so the exact time of a run is visible (`6/23/26, 2:32:05 PM`), matching the wiki's web session pages (mad-labs-org/tbh-wiki#444).

## Key changes

- `formatDateTime` (`app/src/renderer/src/lib/format.ts`) switched the time from `timeStyle: "short"` to `timeStyle: "medium"`, which includes seconds while keeping the OS/locale 12h/24h conventions.

## Screenshots

Text-format-only change, no layout change. Before: `6/23/26, 2:32 PM` → After: `6/23/26, 2:32:05 PM`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor / chore / docs (no user-visible behavior change)

## How was this tested?

- [x] `app/`: `pnpm check` and `pnpm test` pass
- [ ] `reader/`: `ruff check .` and `pytest` pass
- [ ] Manually verified in the running app (Windows for the reader path; macOS dev renders the UI only)

## Checklist

- [x] Conventional commit subjects — they drive the computed release version and the changelog
- [x] Self-reviewed the diff
- [x] No hand-edits to generated/synced files (`app/src/shared/data/`, `app/src/renderer/public/{sprites,heroes}/`) — edit the `data/` snapshot via `scripts/refresh-game-data.mjs` instead
- [x] No secrets committed