### PR TITLE
fix(reader): recover live XP/level on 1.00.20 via ACTk cipher decode

### DIFF
--- a/reader/config/offsets.py
+++ b/reader/config/offsets.py
@@ -93,10 +93,11 @@ class Singleton:
 
 # ACTk Obscured struct layout (CodeStage.AntiCheat.ObscuredTypes): hash@0x0, hiddenValue@0x4,
 # currentCryptoKey@0x8, fakeValue@0xC. Through 1.00.19 the PLAIN `fakeValue` decoy was kept in sync
-# with the real value, so reading it was legal. hidden^key gives GARBAGE (off-limits — see
-# docs/invariants/obscured-data-offlimits). 1.00.20 KILLED the fakeValue decoy build-wide (reads 0):
-# the only remaining source is the cipher, which is off-limits. Live values that used the decoy
-# (HeroRuntime level/exp) now degrade to the save — see HeroRuntime below + game/build.read_live_party.
+# with the real value, so reading it was legal; 1.00.20 KILLED the decoy build-wide (reads 0). The live
+# HeroRuntime level/exp are now RECOVERED by decoding the cipher in game/obscured.py (algorithm read
+# from the binary: int = (hidden-key)^key, float = f32(key^byteswap(hidden)) — note a plain hidden^key is
+# GARBAGE, the refuted first guess). The Unit/Monster CORE-STAT ciphers stay off-limits (no validated
+# decode + a PLAIN substitute already exists) — see docs/invariants/obscured-data-offlimits.
 ACTK_FAKE = 0xC
 
 
@@ -278,18 +279,24 @@ class StageInfoData:                   # catalog (currentStageKey encodes the mo
 
 
 # ----- hero progression runtime (reached via Unit.CACHE) -----
-class HeroRuntime:                     # `uf` (uf : uo)
-    INFO = 0x30                        # beew -> HeroInfoData (for HeroKey/class) — reads LIVE, the
-                                       # live party IDENTITY (game/build.read_live_party).
-    STATS_HOLDER = 0x10                # behg -> xd (holder of the 64 stats) — reads LIVE.
-    # DEAD since 1.00.20: these are the ACTk `fakeValue` decoy (ObscuredInt/Float base+0xC). The
-    # recompile zeroed the decoy build-wide -> they READ 0; the real live level/exp moved behind the
-    # cipher (hiddenValue/currentCryptoKey @ base+0x4/+0x8), which is OFF-LIMITS
-    # (docs/invariants/obscured-data-offlimits). read_live_party no longer reads them — it sources
-    # level/exp from the save. KEPT as dump history + for the _raw_hero_list diagnostic; DO NOT revive
-    # them as a live source (a 0 gate rejects every real hero; decoding the cipher is forbidden).
-    LEVEL_FAKE = 0xD8                  # befp.fakeValue (DEAD: reads 0 since 1.00.20)
-    EXP_FAKE = 0x118                   # beft.fakeValue (DEAD: reads 0 since 1.00.20)
+class HeroRuntime:                     # hero progression runtime (1.00.20 dump: class `vc`,
+                                       # TypeDefIndex 2797), reached via Unit.CACHE.
+    INFO = 0x30                        # -> HeroInfoData (HeroKey/class) — LIVE party IDENTITY.
+    STATS_HOLDER = 0x10                # -> xd (holder of the 64 stats) — LIVE.
+    # LIVE level/exp. 1.00.20 moved them behind the ACTk cipher (the PLAIN `fakeValue` decoy @ +0xC was
+    # zeroed build-wide). RECOVERED read-only by decoding the cipher IN PLACE — the algorithm was read
+    # from the binary (disasm of op_Implicit in GameAssembly.dll) and reimplemented in game/obscured.py:
+    #   ObscuredInt level  (record @0xCC)  = (hidden - key) ^ key
+    #   ObscuredFloat xp   (record @0x10C) = float32(key ^ byteswap_1_2(hidden))
+    # hidden @ base+0x4, key @ base+0x8; the key is read live each tick (handles ACTk key-rotation).
+    # Gated by the validate_live oracle (decoded == save level/xp) — see obscured-data-offlimits.
+    # Confirmed live (1.00.20): level 91/94/101 == save; xp gain Sorcerer ~749K/run == measured 748K.
+    LEVEL_HIDDEN = 0xD0                # ObscuredInt level (record 0xCC): hiddenValue   @ +0x4
+    LEVEL_KEY = 0xD4                   #                                  currentCryptoKey @ +0x8
+    EXP_HIDDEN = 0x110                 # ObscuredFloat xp (record 0x10C): hiddenValue   @ +0x4
+    EXP_KEY = 0x114                    #                                  currentCryptoKey @ +0x8
+    LEVEL_FAKE = 0xD8                  # ObscuredInt level fakeValue (DEAD: reads 0 since 1.00.20) — kept
+    EXP_FAKE = 0x118                   # ObscuredFloat xp fakeValue  (DEAD: reads 0)  for _raw_hero_list
 
 
 class StatsHolder:                     # `xd` (dump.cs:342026)

--- a/reader/docs/invariants/metric-fallback-chains.md
+++ b/reader/docs/invariants/metric-fallback-chains.md
@@ -56,7 +56,8 @@ delta (`CurrencySaveData.QUANTITY`): it includes sale and idle, so `gold_end −
 symptoms: frozen cell → **gold 0**; heap garbage → **1.97T**.
 
 **XP.** LIVE = the **per-hero ACCUMULATOR** (`PartyXpAccumulator` in `metrics/xp.py`): it integrates
-the within-level increments (`HeroRuntime.EXP_FAKE`) **tick-by-tick** (snapshot ~1s + a final tick
+the within-level increments (the live exp decoded from the ACTk ObscuredFloat, `game/obscured.py` —
+since 1.00.20 the `EXP_FAKE` decoy is dead) **tick-by-tick** (snapshot ~1s + a final tick
 at close), keyed by IDENTITY (heroKey) — the 1st sighting seeds the baseline, the level-up bridges
 across the curve (`per_hero_gain`), and late-deploy/death/dropout **do not lose the accumulated
 total** (banked; a dead hero accumulates 0 while dead — real game behavior, preserved). It replaced
@@ -68,8 +69,8 @@ level-up). The choice lives in the orchestrator (`close_run` in `meter_windows.p
 SAVE, never to a silent 0.
 
 **XP at cap.** The curve DEFINES the cap: a level with no entry has no progression (`level_capped`) —
-but the game keeps incrementing `EXP_FAKE` (and the save's `HeroExp`) on a hero AT cap, with no
-level-up to consume/reset → the same-level delta is **PHANTOM XP**. A hero at cap gains **0** (a VALID
+but the game keeps incrementing the within-level exp (and the save's `HeroExp`) on a hero AT cap, with
+no level-up to consume/reset → the same-level delta is **PHANTOM XP**. A hero at cap gains **0** (a VALID
 zero gain in `per_hero_gain`, never `None` — `None` would silently degrade to SAVE, which has the SAME
 hole, so `close_run` also zeroes the save-side delta of a capped hero); crossing INTO the cap banks
 only up to the threshold (`xp_through_levelup` counts `exp1` only if the final level is on the curve);

--- a/reader/docs/invariants/obscured-data-offlimits.md
+++ b/reader/docs/invariants/obscured-data-offlimits.md
@@ -16,6 +16,7 @@ code_anchors:
   - config/offsets.py::Monster.CACHE_OBSCURED
   - config/offsets.py::EEquipClassType
   - config/offsets.py::StatsHolder.FINAL_STATS
+  - game/obscured.py::decode_obscured_float
 asserts:
   - config.offsets.Unit.CORE_STATS_OBSCURED == 0x104
   - config.offsets.Monster.CACHE_OBSCURED == 0x3B8
@@ -49,18 +50,44 @@ anchor on them and the test can guard them. They **must not be referenced by any
 (`metrics/`, `game/`) — if a module cites `CORE_STATS_OBSCURED`/`CACHE_OBSCURED`, it's because someone is
 about to read there, and `guarded_by` fails on purpose.
 
-## The dead `fakeValue` decoy is NOT a back door (1.00.20)
+## The dead `fakeValue` decoy is recovered by decoding the cipher (1.00.20+)
 
 ACTk keeps each Obscured value as `hash / hiddenValue / currentCryptoKey / fakeValue` (the cipher fields +
-a PLAIN `fakeValue` decoy at base+`ACTK_FAKE`). When the build keeps the decoy in sync with the real value
-(through 1.00.19), reading the decoy is legal — that is how the live hero level/exp were read
-(`HeroRuntime.LEVEL_FAKE`/`EXP_FAKE`). **1.00.20 zeroed the decoy build-wide** (it reads 0). The tempting
-"fix" is to read `hiddenValue ^ currentCryptoKey` instead — that is **reading the cipher, forbidden by
-this invariant** (ObscuredFloat decodes that way, ObscuredInt uses a heavier transform; either way ACTk
-rotates the key and the decode-method name every build, so it re-breaks). When a decoy dies, the value is
-**gone** — degrade to the PLAIN substitute (the save), never decode. See `HeroRuntime` in `config/offsets.py`
-(the dead offsets are kept as dump history, marked DO-NOT-REVIVE) and `game/build.read_live_party`
-([[invariants/party-live-resolution]]).
+a PLAIN `fakeValue` decoy at base+`ACTK_FAKE`). Through 1.00.19 the decoy was kept in sync with the real
+value, so reading it was legal — that is how the live hero level/exp were read. **1.00.20 zeroed the decoy
+build-wide** (it reads 0). Degrading to the PLAIN substitute (the save) is *visibly* wrong for xp — the
+per-run save delta jumps ~2× ([[invariants/metric-fallback-chains]]), the bug players reported. So for the
+hero level/exp we now RECOVER the live value by decoding the cipher in place. The value is NOT gone: ACTk
+keeps the key (`currentCryptoKey @ +0x8`) right next to `hiddenValue @ +0x4`, so a reader with both words
+can invert it.
+
+**The decode was READ FROM THE BINARY, not guessed.** A first guess (`hidden ^ key`) was REFUTED live
+(garbage that jittered ±5M). Disassembling the `op_Implicit` accessors in `GameAssembly.dll` gave the real
+algorithms, reimplemented in `game/obscured.py`:
+- **ObscuredInt** (RVA 0x6E6CA0): `value = (hidden - key) ^ key`.
+- **ObscuredFloat** (RVA 0x6E4C00): `value = float32(key ^ byteswap_1_2(hidden))` (bytes [1],[2] of
+  `hidden` swapped — the ACTkByte4 shuffle — before the XOR).
+
+Why this is recoverable WITHOUT the fragility the old guidance feared:
+- **Build-independent algorithm.** We reimplement it in Python; we never resolve/call the game's decrypt
+  method (its IL2CPP name is obfuscated and drifts per build — the math does not).
+- **Key rotation is handled.** The caller reads `currentCryptoKey` live every tick next to `hiddenValue`;
+  the key is never cached.
+- **Never a silent wrong number.** the decoders return `None` if either word was unreadable (mirrors
+  `ru32`→None), so the caller degrades to SAVE rather than emitting garbage (None-vs-0 discipline,
+  [[invariants/metric-fallback-chains]]).
+
+LIVE now: `game/build.read_live_party` decodes the hero LEVEL (`HeroRuntime.LEVEL_HIDDEN`/`_KEY`) and the
+within-level XP (`EXP_HIDDEN`/`_KEY`); the dead `fakeValue` offsets stay only as `_raw_hero_list` history.
+
+**What stays guarded.** The algorithm is build-INDEPENDENT, but the struct BASE can move on a recompile
+(like every offset in 1.00.14) and the dev could swap the cipher. Both are caught LOUDLY by the oracle
+(decoded == real level/xp) — `tests/test_obscured.py` pins the math + GOLDEN LIVE VECTORS (level 91/94/101
+== save; Ranger xp exact at the cap), and `scripts/validate_live.py` should re-check it per build. That
+tripwire is the "find it again, always" guarantee: a cipher change fails the gate loudly, never silently
+wrong. The `Unit.CORE_STATS_OBSCURED` / `Monster.CACHE_OBSCURED` markers below remain DO-NOT-READ: those
+are different Obscured fields with no validated decode and a PLAIN substitute that is already correct —
+decode is only worth it where the PLAIN/SAVE substitute is visibly wrong (xp), not a blanket license.
 
 ## Orphan enum: hero class identity
 

--- a/reader/docs/invariants/party-live-resolution.md
+++ b/reader/docs/invariants/party-live-resolution.md
@@ -38,17 +38,16 @@ A run's canonical party is the **DEPLOYED** heroes — their IDENTITY (the heroK
 Ranger is on the field. Confusing roster with party means showing unplayed heroes (the symptom: several
 with `+0xp`).
 
-**Identity is LIVE; level/exp degrade to the save (1.00.20).** Through 1.00.19, `read_live_party` also
-read each deployed hero's live within-level level/exp from the ACTk `fakeValue` PLAIN decoy
-(`HeroRuntime.LEVEL_FAKE`/`EXP_FAKE`). The 1.00.20 recompile ZEROED that decoy build-wide; the real live
-level/exp moved behind the ObscuredInt/Float cipher, which is **off-limits**
-([[invariants/obscured-data-offlimits]] — decoding `hidden^key` is forbidden and would re-break every
-build). So `read_live_party` now sources level from the **save** and forces **exp = None**. This keeps the
-PARTY fully LIVE (membership is still `StageManager.HeroList`); only the level/exp *values* fall back to
-the save (LIVE→SAVE, [[invariants/metric-fallback-chains]]) — it NEVER lets the roster define the party.
-`exp = None` is deliberate: feeding the stale save exp into the live xp accumulator would make the SAVE
-fallback masquerade as `xp_source="live"` (forbidden), so the accumulator stays empty, `xp_total_live`
-is `None`, and `close_run` honestly tags the run's xp `save` (capped heroes → 0, as ever).
+**Identity AND level/exp are LIVE (1.00.20+).** Through 1.00.19, `read_live_party` read each deployed
+hero's level/exp from the ACTk `fakeValue` PLAIN decoy (`HeroRuntime.LEVEL_FAKE`/`EXP_FAKE`). The 1.00.20
+recompile ZEROED that decoy build-wide; rather than degrade to the lagging save (whose per-run delta jumps
+~2× — the bug players reported), `read_live_party` now RECOVERS the values by decoding the ObscuredInt
+level + ObscuredFloat xp in place (`game/obscured.py`; the algorithm was read from the binary, gated by
+the validate_live oracle — see [[invariants/obscured-data-offlimits]]). The party stays fully LIVE
+(membership is `StageManager.HeroList`); LEVEL falls back to the save on an unreadable cipher, and EXP
+stays `None` on a bad read so the xp chain degrades HONESTLY (never the stale save exp masquerading as
+`xp_source="live"`, [[invariants/metric-fallback-chains]]) — it NEVER lets the roster define the party.
+Capped heroes → 0 xp, as ever.
 
 ## `pick_live_sm`: NO cap, and the SAME validation as `read_live_party`
 

--- a/reader/game/build.py
+++ b/reader/game/build.py
@@ -1,6 +1,6 @@
 """build.py — reads the hero's BUILD: equips/mods/skills (from the save) + the 64 live
 FINAL stats (id-only) + the LIVE deployed party identity (heroKeys from StageManager.HeroList;
-level/exp degrade to the save since 1.00.20 killed the ACTk live decoy — see read_live_party).
+level/exp read LIVE by decoding the ACTk cipher in place since 1.00.20 — see read_live_party).
 Mirrors the monolith.
 
 The 64 stats come out keyed by statId int (id-only; the front resolves the name). The
@@ -16,6 +16,7 @@ from config.offsets import (HeroRuntime, StatsHolder, Dict, DictFloat, Array, Li
                             AttributeSaveData, ItemSaveData, ItemEnchant, name_map,
                             EItemParts, EGradeType, EEquipClassType, ERecipeType, StatType,
                             RuneSaveData, InventorySaveData, StashSaveData)
+from game import obscured
 from shared.utils import resource_path
 
 _PARTS = name_map(EItemParts)
@@ -81,20 +82,19 @@ def read_attribute_levels(reader, psd):
 
 def read_live_party(reader, sm, hero_cat=None, save_heroes=None):
     """{heroKey: (level, exp)} for the LIVE DEPLOYED party (StageManager.HeroList). The party
-    IDENTITY (which heroKeys are on the field) is read LIVE — the invariant party source — and the
-    per-hero level/exp are sourced from `save_heroes` (the live within-level decoy died, see below).
+    IDENTITY (which heroKeys are on the field) AND the per-hero level/exp are all read LIVE.
     Never raises -> {} on any failure.
 
-    1.00.20 — why level/exp no longer come from memory here. Through 1.00.19 the live level/exp were
-    the ACTk `fakeValue` PLAIN decoys (HeroRuntime.LEVEL_FAKE/EXP_FAKE @ base+0xC of the ObscuredInt/
-    Float), kept in sync with the real value, so reading them was legal. In 1.00.20 the recompile
-    KILLED those decoys build-wide (they read 0); the real live level/exp moved BEHIND the ObscuredInt
-    cipher (hiddenValue/currentCryptoKey @ base+0x4/+0x8) — and decoding the cipher is exactly what
-    [[invariants/obscured-data-offlimits]] forbids (hidden^key is garbage; ACTk rotates the key + the
-    decode-method name every build). The decoy can't be revived. So the live WITHIN-LEVEL exp is gone:
-    level/exp degrade to the SAVE (`save_heroes`, the lagging within-level snapshot — the same fallback
-    the xp chain already uses). This keeps the party LIVE while only the level/exp VALUES degrade
-    (LIVE->SAVE, [[invariants/metric-fallback-chains]]); it NEVER lets the roster define the party.
+    1.00.20 — level/exp are decoded from the ACTk cipher IN PLACE. Through 1.00.19 the live level/exp
+    were the ACTk `fakeValue` PLAIN decoys (@ base+0xC of the ObscuredInt/Float). In 1.00.20 the
+    recompile KILLED those decoys build-wide (they read 0); the real live values stayed in the cipher
+    (hiddenValue @ base+0x4, currentCryptoKey @ base+0x8). Rather than degrade to the lagging save (the
+    per-run save delta jumps ~2× — the bug players reported), we RECOVER the live values by decoding the
+    cipher read-only (game/obscured.py — algorithm read from the binary, not guessed; ObscuredInt level =
+    (hidden-key)^key, ObscuredFloat xp = float(key ^ byteswap(hidden))). The key is read live each tick
+    (handles ACTk rotation). LEVEL falls back to the save on an unreadable cipher; EXP stays None on a bad
+    read so the xp chain degrades honestly ([[invariants/metric-fallback-chains]] rule 2), never the
+    roster. The decode is gated by the validate_live oracle — see [[invariants/obscured-data-offlimits]].
 
     Ghost discriminator (replaces the dead `lvl>0` filter). The scan/backref returns torn-down/template
     StageManager 'ghosts' alongside the live carrier ([[invariants/instance-selection]] family). The
@@ -132,15 +132,19 @@ def read_live_party(reader, sm, hero_cat=None, save_heroes=None):
             # carries a stale/garbage key that doesn't. heroKey-plausibility only when hero_cat is absent.
             if hero_cat is not None and hk not in hero_cat:
                 continue
-            # LEVEL from the SAVE (the live decoy is dead; the live level is behind the cipher, off-
-            # limits) — informative for the overlay/diagnostics. EXP is FORCED None: the live WITHIN-
-            # LEVEL exp is gone, and feeding the stale SAVE exp into the live xp accumulator would make
-            # the SAVE fallback silently report as LIVE (xp_source="live") — forbidden by
-            # [[invariants/metric-fallback-chains]] rule 2. None keeps the accumulator EMPTY, so close_run
-            # honestly tags the run's xp `save` and uses the per-hero save delta (capped→0). The party
-            # IDENTITY stays fully LIVE; only level/exp degrade.
-            lvl = (save_heroes or {}).get(hk, (None, None))[0]
-            res[hk] = (lvl, None)
+            # LEVEL + EXP read LIVE by decoding the ACTk cipher in place (the +0xC decoy died in
+            # 1.00.20). game/obscured.py reimplements the decode read from the binary. LEVEL falls back
+            # to the save snapshot on an unreadable/implausible cipher (stable, context only). EXP stays
+            # None on a bad read — NEVER the stale save exp — so close_run degrades to the per-hero save
+            # delta honestly ([[invariants/metric-fallback-chains]] rule 2), instead of reporting save as
+            # live. The party IDENTITY remains the live heroKey gate above.
+            lvl = obscured.decode_obscured_int(reader.ru32(uf + HeroRuntime.LEVEL_HIDDEN),
+                                               reader.ru32(uf + HeroRuntime.LEVEL_KEY))
+            if lvl is None or not (0 < lvl <= 200):
+                lvl = (save_heroes or {}).get(hk, (None, None))[0]
+            exp = obscured.decode_obscured_float(reader.ru32(uf + HeroRuntime.EXP_HIDDEN),
+                                                 reader.ru32(uf + HeroRuntime.EXP_KEY))
+            res[hk] = (lvl, exp)
     except Exception:
         return {}
     return res

--- a/reader/game/obscured.py
+++ b/reader/game/obscured.py
@@ -1,0 +1,54 @@
+"""obscured.py — decode ACTk (CodeStage.AntiCheat) Obscured values from their OWN struct.
+
+The decode algorithms below were READ FROM THE 1.00.20 BINARY (disassembly of the op_Implicit
+accessors), NOT guessed — an earlier plain-XOR guess produced garbage and was refuted live. ACTk keeps
+the key IN THE SAME STRUCT (`currentCryptoKey @ +0x8`, next to `hiddenValue @ +0x4`), so a read-only
+reader can decode without calling the game's (per-build-renamed) method.
+
+ObscuredInt  (struct: hash@0x0 hidden@0x4 key@0x8 fake@0xC; GameAssembly.dll RVA 0x6E6CA0):
+    value = ((hidden - key) & 0xFFFFFFFF) ^ key            # int32
+    Disasm core: `mov edi,[hidden]; sub edi,[key]; xor edi,[key]`. CONFIRMED live: the hero LEVEL
+    field decodes to 91/94/101 == the save levels (3/3 exact).
+
+ObscuredFloat (struct: hash@0x0 hidden@0x4 key@0x8 fake@0xC (float) ...; RVA 0x6E4C00):
+    value = reinterpret_f32( key ^ byteswap_1_2(hidden) )  # bytes [1] and [2] of `hidden` swapped
+    Disasm core: load hidden -> swap bytes 1,2 (helper 0x1807117F0) -> `xor key` -> `movd xmm,...`.
+    CONFIRMED live: the hero within-level XP decodes to the save XP (Knight ~1.44e9≈1.45e9,
+    Ranger 256,967,868,416 == save 256.97e9 EXACT at the cap where it's frozen).
+
+Why this is robust ("find it again, always"): the algorithm is ACTk's, reimplemented here, so it does
+NOT change when the game's obfuscated method names drift; the key is read live each tick (handles ACTk
+key-rotation — never cache it). What CAN move (the struct base offset on a recompile, or a cipher
+swap) is caught LOUDLY by the oracle (decoded == real level/xp) in scripts/validate_live.py — never
+silently wrong. See [[invariants/obscured-data-offlimits]].
+
+PURE (no memory access): the caller reads `hidden`/`key` (ru32 -> None on a bad read) and passes them.
+None propagates -> the caller degrades to SAVE, never a wrong 0 ([[invariants/metric-fallback-chains]]).
+"""
+
+import struct
+
+
+def _byteswap_1_2(v):
+    """Swap bytes [1] and [2] of a 32-bit little-endian word (ACTkByte4 shuffle the ObscuredFloat
+    decode applies before the XOR). Its own inverse."""
+    return (v & 0xFF) | ((v >> 16) & 0xFF) << 8 | ((v >> 8) & 0xFF) << 16 | (v & 0xFF000000)
+
+
+def decode_obscured_int(hidden, key):
+    """ACTk ObscuredInt -> the real int32 (signed). `hidden`/`key` are the raw u32 words at the
+    struct's hiddenValue/currentCryptoKey offsets. None if either word was unreadable (-> caller
+    degrades to SAVE, never emits a bogus 0)."""
+    if hidden is None or key is None:
+        return None
+    raw = ((((hidden - key) & 0xFFFFFFFF) ^ key) & 0xFFFFFFFF)
+    return struct.unpack("<i", struct.pack("<I", raw))[0]
+
+
+def decode_obscured_float(hidden, key):
+    """ACTk ObscuredFloat -> the real float32. Byte-swap [1]<->[2] of `hidden`, XOR the key,
+    reinterpret as float32. None if either word was unreadable."""
+    if hidden is None or key is None:
+        return None
+    bits = (key ^ _byteswap_1_2(hidden)) & 0xFFFFFFFF
+    return struct.unpack("<f", struct.pack("<I", bits))[0]

--- a/reader/meter_windows.py
+++ b/reader/meter_windows.py
@@ -848,10 +848,10 @@ def run(hz, output_dir, debug=False):
 
     csd = save.pick_live_csd(reader, csd_list, stage_info)
     # The live party IDENTITY (heroKeys) gates on hero_cat (the ghost discriminator since 1.00.20 — see
-    # build.read_live_party); level/exp come from the save (the live decoy died). pick_live_sm gets
-    # hero_cat so pick<->read agree on the carrier.
+    # build.read_live_party); level/exp are decoded live there. pick_live_sm gets hero_cat so pick<->read
+    # agree on the carrier.
     sm = save.pick_live_sm(reader, sm_list, hero_cat)
-    print(f"[live party] StageManager {'ok' if sm else 'NOT found (live xp off, uses save)'}"
+    print(f"[live party] StageManager {'ok' if sm else 'NOT found (no live party/xp)'}"
           f" — {len(build.read_live_party(reader, sm, hero_cat))} heroes deployed.")
     # infra-log: the pick decision in detail — candidates, REAL carriers vs ghosts (heroKey ok but not a
     # catalog hero), which one was picked + a sample of ghosts. THIS was missing in the 1.00.13 debug:
@@ -917,8 +917,8 @@ def run(hz, output_dir, debug=False):
         if not sm:
             sm = save.pick_live_sm(reader, sm_list, hero_cat)
         p = save.pick_live_psd(reader, psd_list)
-        # LIVE party identity (heroKeys, gated on hero_cat); level/exp from the save snapshot (the live
-        # decoy died in 1.00.20). save_heroes = {heroKey: (level, exp)} for the deployed heroes.
+        # LIVE party identity (heroKeys, gated on hero_cat); level + within-level exp decoded live in
+        # read_live_party (save_heroes = the snapshot passed for the level fallback on a bad decode).
         _sh = save.read_heroes(reader, p)
         pl0 = build.read_live_party(reader, sm, hero_cat, _sh)
         # LIVE per-hero xp accumulator (metrics.xp.PartyXpAccumulator) — the primary LIVE of the
@@ -1048,12 +1048,12 @@ def run(hz, output_dir, debug=False):
         # delta (t=0 baseline → read at close), which gave +0 to a hero OUTSIDE the baseline (late deploy
         # / a dead hero from the previous run revived: gain=None → +0 in the app) — the accumulator banks
         # the gain of whoever died (a dead hero accumulates 0 while dead, real game behavior, preserved).
-        # 1.00.20: the live within-level exp DIED (EXP_FAKE decoy zeroed; the real value is behind the
-        # off-limits cipher), so read_live_party yields exp=None → the accumulator sees nobody →
-        # xp_live_ok=False → xp falls back to xp_gain (the per-hero SAVE delta) tagged xp_source="save".
+        # 1.00.20: the live within-level exp is decoded from the ACTk cipher in read_live_party and feeds
+        # the accumulator → xp_source="live". If a decode fails (exp None → accumulator saw nobody →
+        # xp_live_ok=False), xp falls back to xp_gain (the per-hero SAVE delta) tagged xp_source="save".
         xpacc = R["xp_acc"]
-        # LIVE party identity (gated on hero_cat); level/exp from heroes_end (the save snapshot already
-        # read above) since the live decoy died in 1.00.20. never-raises -> {} on failure.
+        # LIVE party identity (gated on hero_cat); level/exp decoded live in read_live_party (heroes_end
+        # is the save snapshot, passed for the level fallback on a bad decode). never-raises -> {}.
         pl_end = build.read_live_party(reader, sm, hero_cat, heroes_end)
         xpacc.update(pl_end)
         R["party_seen"].update(dict.fromkeys(pl_end))  # live at close = seen (live_keys ⊇ acc)
@@ -1103,10 +1103,9 @@ def run(hz, output_dir, debug=False):
                 # No live accumulator record for this hero -> per-hero SAVE fallback (xp_by_hero),
                 # NEVER None/+0 (the boundary-death bug) nor the roster.
                 # Two cases:
-                #  - LIVE xp source DEAD build-wide (1.00.20: within-level exp behind the cipher ->
-                #    read_live_party yields exp=None -> the acc saw NOBODY, xp_live_ok=False). This is
-                #    the EXPECTED honest "live xp off" degradation (the whole run is already tagged
-                #    xp_source="save") — NOT an anomaly, so no ⚠ (it would fire for every hero, every run).
+                #  - the live xp source saw NOBODY (xp_live_ok=False: every hero's cipher decode failed,
+                #    or sm was off the whole run) -> the run already degraded to xp_source="save", so this
+                #    is the EXPECTED honest fallback, NOT an anomaly -> no ⚠.
                 #  - The acc saw SOMEONE but missed THIS hero (xp_live_ok=True): a real regression (the acc
                 #    eats the SAME reads that feed pl_start/party_seen) -> ⚠ makes it OBSERVABLE: if it
                 #    fires, sum(heroes.xp) exceeds the run total (acc excludes this save-sourced hero).
@@ -1419,18 +1418,17 @@ def run(hz, output_dir, debug=False):
                 # is read ONCE here and reused for xp + frame. The build stays only at close.
                 if not sm:  # found lazily when the player enters a stage
                     sm = save.pick_live_sm(reader, sm_list, hero_cat)
-                # Live save (for level/exp + the gold/xp fallback). Picked BEFORE the party so
-                # read_live_party can source level from it (the live decoy died in 1.00.20).
+                # Live save (for the level fallback + the gold/xp save fallback). Picked BEFORE the party.
                 psd = save.pick_live_psd(reader, psd_list)
                 heroes_now = save.read_heroes(reader, psd) if psd else {}
-                # LIVE party identity (heroKeys, gated on hero_cat); level from heroes_now, exp None
-                # (live within-level exp is gone -> the accumulator stays empty -> honest save fallback).
+                # LIVE party identity (heroKeys, gated on hero_cat); level + within-level exp decoded live
+                # in read_live_party (heroes_now is the save snapshot, for the level fallback on a bad decode).
                 pl_end = build.read_live_party(reader, sm, hero_cat, heroes_now)
                 R["party_seen"].update(dict.fromkeys(pl_end))
                 # LIVE xp accumulator (the SAME object that closes the run in close_run): integrates the
-                # per-hero tick — the 1st sighting seeds the baseline; then sums increments > 0
-                # (level-up by the curve). Since 1.00.20 read_live_party yields exp=None, so the acc sees
-                # nobody and total() stays None -> the overlay xp uses the SAVE fallback below (honest).
+                # per-hero tick — the 1st sighting seeds the baseline; then sums increments > 0 (level-up by
+                # the curve). Fed the live decoded exp → drives the overlay's live xp/ETA; the SAVE fallback
+                # below only kicks in if the decode fails (total() None).
                 R["xp_acc"].update(pl_end)
                 # 64 live FINAL stats per hero (same read as the close). Additive in live.json:
                 # feeds the per-hero effective-resistance tooltip in the overlay. never-raises -> {}.

--- a/reader/metrics/xp.py
+++ b/reader/metrics/xp.py
@@ -7,12 +7,12 @@ the curve (config/level_curve.json = ExpForLevelUp per level) fills the wrap. Va
 across 3 level-ups the sum matched with diff 0. Within-level is MONOTONIC outside level-up
 (the dip detector ran many runs with a death and never fired) — death only PAUSES the gain.
 
-1.00.20: the live within-level exp DIED (the EXP_FAKE decoy zeroed build-wide; the real value moved
-behind the off-limits ObscuredFloat cipher — see config/offsets.HeroRuntime + obscured-data-offlimits).
-build.read_live_party now yields exp=None, so the accumulator sees NOBODY (total()->None) and the
-orchestrator falls back to the per-hero SAVE delta, honestly tagging xp_source="save"
-([[invariants/metric-fallback-chains]]). The accumulator logic below is unchanged — it just no longer
-gets fed a live exp until/unless a future build restores a readable one.
+1.00.20: the live within-level exp was hidden behind the ACTk ObscuredFloat cipher (the PLAIN
+EXP_FAKE decoy was zeroed build-wide). It is now RECOVERED — build.read_live_party decodes the cipher
+in place (game/obscured.py, algorithm read from the binary), so the accumulator is fed a clean live
+exp again and the run tags xp_source="live" (confirmed: gain matches the screen ~749K/run). The SAVE
+delta remains the honest fallback if the decode ever fails ([[invariants/metric-fallback-chains]] /
+[[invariants/obscured-data-offlimits]]). The accumulator logic below is unchanged.
 
 CAP: a level with no curve entry has no defined progression (level_capped) — the game keeps
 incrementing the within-level exp at the cap with no level-up to consume it, so the same-level delta is
@@ -176,10 +176,9 @@ def party_progress(acc, party):
 
     Assembles ALREADY-read values (no memory, no clock):
       - `level`/`exp`: within-level values from read_live_party. `exp` resets on level-up, so the app's
-        "remaining to next level" is curve[level] - exp. SINCE 1.00.20 read_live_party yields exp=None
-        (the live within-level exp died — see the module docstring), so this loop SKIPS every hero and
-        returns {} → the overlay shows no live ETA (HONEST: there is no live rate to project). It
-        re-activates automatically if a future build restores a readable within-level exp.
+        "remaining to next level" is curve[level] - exp. Since 1.00.20 these come from decoding the ACTk
+        cipher in read_live_party (the live ETA works again); a hero whose cipher read fails is skipped
+        (exp None) — HONEST: no live rate to project for it — and re-appears once readable.
       - `gain`: the run's accumulated XP for that hero (PartyXpAccumulator.gain, level-up-bridged), from
         which the app derives the live rate (delta gain / delta t) and the ETA. 0.0 = seen with no gain
         yet (just-deployed, or AT the cap where gain is phantom-suppressed) -> the app shows "-"/"MAX".

--- a/reader/scripts/validate_live.py
+++ b/reader/scripts/validate_live.py
@@ -20,8 +20,8 @@ VALIDATES (with the game OPEN and IN COMBAT on a stage):
   [build-record] read_build (the heroes[] the run UPLOADS) >=1 hero AND >=1 with items[] OR skills[]
                  (proves ATTRIBUTES/ITEMS/EQUIPPED_* — not just HEROES) + read_account_snapshot
                  (runes/inventory/stash) not-all-None (proves RUNES/INVENTORY/STASH/ITEMS)
-  [xp-live]     the deployed heroes carry a plausible save LEVEL (the live within-level exp died in
-                1.00.20 → xp degrades to the save; read_live_party returns exp=None by design)
+  [xp-live]     each deployed hero's level+xp DECODE from the ACTk cipher and the decoded LEVEL matches
+                the save (the per-build tripwire: a moved/changed cipher diverges from the save → FAIL)
   [dps]         MonsterSpawnManager + UnitHealthController: >=1 live monster with hp_max>0
   [stats]       StatsHolder.FINAL_STATS (DictFloat): >=1 hero with a dict of ~64 live stats
   [stage]       the LIVE stage key (Monster.STAGE_KEY) resolves an entry in the StageInfoData catalog
@@ -32,6 +32,7 @@ USAGE (Windows, ADMIN, game open and IN COMBAT):  python reader\\scripts\\valida
 Exit 0 = all PASS (safe to ship). Exit != 0 = some metric FAILed (do NOT ship). Tees to
 validate_live_out.txt next to the file. Does NOT write to the game or the real resolve_cache.
 """
+import math
 import os
 import sys
 import time
@@ -52,8 +53,9 @@ import meter_windows as mw                                       # noqa: E402
 from shared.memory import Reader, find_pid, open_process         # noqa: E402
 from il2cpp import typeinfo                                      # noqa: E402
 from metrics import gold                                         # noqa: E402
-from game import save, build, models                             # noqa: E402
-from config.offsets import CommonSaveData, List, LogManager, EEquipClassType, MonsterSpawnManager, Unit  # noqa: E402
+from game import save, build, models, obscured                   # noqa: E402
+from config.offsets import (CommonSaveData, List, LogManager, EEquipClassType, MonsterSpawnManager,  # noqa: E402
+                            Unit, StageManager, Array, HeroRuntime, HeroInfoData)
 
 # Valid classId range = the REAL members of EEquipClassType (single-source: derived from the enum,
 # not a literal). CLASS_TYPE is EEquipClassType, NEVER EHeroType (orphan) — see the obscured invariant.
@@ -119,8 +121,8 @@ def main():
 
     # [party-live] StageManager resolves + 1..12 DEPLOYED heroes (the REAL party, not the save roster).
     # The party IDENTITY is read LIVE and gated on hero_cat (the ghost discriminator since 1.00.20 — the
-    # ACTk live level decoy died, so the old lvl>0 gate would reject every real hero). Level/exp degrade
-    # to the save inside read_live_party; here we pass save_heroes so the keys carry their save level.
+    # ACTk live level decoy died, so the old lvl>0 gate would reject every real hero). Level/exp are
+    # decoded live inside read_live_party; save_heroes is passed for the level fallback on a bad decode.
     sm = save.pick_live_sm(reader, sm_list, hero_cat)
     save_heroes_live = save.read_heroes(reader, save.pick_live_psd(reader, psd_list))
     party = build.read_live_party(reader, sm, hero_cat, save_heroes_live) if sm else {}
@@ -186,17 +188,33 @@ def main():
                    f"heroes={len(build_recs)} withGearOrSkills={geared} "
                    f"snapshot(runes/inv/stash)={[None if x is None else len(x) for x in snap]}"))
 
-    # [xp-live] xp is sourced for the deployed heroes. 1.00.20: the live within-level exp DIED (the ACTk
-    # decoy zeroed; the real value is behind the off-limits cipher — obscured-data-offlimits), so the live
-    # xp accumulator can't run and xp HONESTLY degrades to the per-hero SAVE delta (xp_source="save", per
-    # metric-fallback-chains). read_live_party now returns (save_level, None). So the live-XP precondition is:
-    # the party resolves AND every deployed hero has a plausible LEVEL from the save (the save xp fallback's
-    # input). exp is None by design (NOT a failure) — asserting "live exp > 0" would assert a value the build
-    # no longer exposes. The save-XP delta itself is exercised by [save-build]/[build-record].
-    xp_ok = bool(party) and all(lvl is not None and 0 < lvl <= 999 for lvl, _exp in party.values())
-    checks.append(("xp-live", xp_ok,
-                   (f"{len(party)} heroes w/ save level (live within-level exp dead since 1.00.20 → xp via save)"
-                    if party else "no live party (in combat?)")))
+    # [xp-live] LIVE level + within-level xp recovered by decoding the ACTk cipher in HeroRuntime
+    # (1.00.20+: the PLAIN +0xC decoy was zeroed). THE ORACLE: decode each deployed hero's level
+    # DIRECTLY here (NOT via read_live_party, which masks a bad decode with the save fallback) and
+    # require it to match the SAVE level (±1 for autosave lag), with xp decoding to a finite, ≥0 float.
+    # A moved/changed cipher makes the decoded level DIVERGE from the save → FAIL: the per-build tripwire
+    # that lets us re-find the value on every update (game/obscured.py + obscured-data-offlimits).
+    xp_oracle = []
+    hl = reader.rptr(sm + StageManager.HERO_LIST) if sm else None
+    nslots = reader.ri32(hl + Array.MAX_LENGTH) if hl else None
+    for i in range(nslots if (nslots is not None and 0 < nslots <= 12) else 0):
+        h = reader.rptr(hl + Array.DATA + i * 8)
+        uf = reader.rptr(h + Unit.CACHE) if h else None
+        hi = reader.rptr(uf + HeroRuntime.INFO) if uf else None
+        hk = reader.ri32(hi + HeroInfoData.HERO_KEY) if hi else None
+        if hk is None or hk not in hero_cat:
+            continue
+        dec_lvl = obscured.decode_obscured_int(reader.ru32(uf + HeroRuntime.LEVEL_HIDDEN),
+                                               reader.ru32(uf + HeroRuntime.LEVEL_KEY))
+        dec_xp = obscured.decode_obscured_float(reader.ru32(uf + HeroRuntime.EXP_HIDDEN),
+                                                reader.ru32(uf + HeroRuntime.EXP_KEY))
+        save_lvl = save_heroes_live.get(hk, (None,))[0]
+        ok = (dec_lvl is not None and save_lvl is not None and abs(dec_lvl - save_lvl) <= 1
+              and dec_xp is not None and math.isfinite(dec_xp) and dec_xp >= 0.0)
+        xp_oracle.append((hk, dec_lvl, save_lvl, dec_xp, ok))
+    checks.append(("xp-live", bool(xp_oracle) and all(o[4] for o in xp_oracle),
+                   " ".join(f"hk{hk}:lv{dl}=save{sl}? xp={dx:.4g}" for hk, dl, sl, dx, _ in xp_oracle)
+                   or "no live party (in combat?)"))
 
     # [dps] MonsterSpawnManager + UnitHealthController: DPS = Σ of monster HP drops. models.live_monsters
     # iterates (unit, hp_cur, hp_max) reading MONSTER_LIST/SUMMONED_LIST + Unit.HEALTH_CONTROLLER + HP@0x40/0x4C.

--- a/reader/tests/conftest.py
+++ b/reader/tests/conftest.py
@@ -28,6 +28,9 @@ class MockReader:
     def rf32(self, addr):
         return self._mem.get(addr)
 
+    def ru32(self, addr):
+        return self._mem.get(addr)
+
     def rptr(self, addr):
         return self._mem.get(addr)
 

--- a/reader/tests/test_live_xp_integration.py
+++ b/reader/tests/test_live_xp_integration.py
@@ -1,0 +1,140 @@
+"""Integration: live-XP recovery through the REAL read path — `read_live_party` decodes the ACTk
+cipher in `HeroRuntime`, feeding the REAL `PartyXpAccumulator`.
+
+Two distinct things are tested (kept apart on purpose):
+  - DECODE + WIRING against GROUND TRUTH: real (hidden, key) words captured from the running 1.00.20
+    game laid into the StageManager.HeroList layout -> `read_live_party` returns the real levels
+    (91/94/101 == save) and the real within-level XP (Ranger exact at the cap). This is NOT a
+    round-trip of our own code — real input, independently-known output (decode correctness itself is
+    further pinned in tests/test_obscured.py against the save).
+  - PIPELINE BEHAVIOR (death banks the gain, revive resumes, max-level = 0, unreadable -> save): the
+    accumulator integration. These use constructed inputs (you can't make the game die on command),
+    so they assert the ACCUMULATOR's real behavior — the gain — not decode correctness.
+"""
+
+import struct
+
+import pytest
+
+from config.offsets import Array, HeroInfoData, HeroRuntime, StageManager, Unit
+from game.build import read_live_party
+from metrics.xp import PartyXpAccumulator
+from tests.conftest import MockReader
+
+SM = 0x1000
+HERO_CAT = {101: 1, 201: 2, 301: 3, 401: 4, 501: 5, 601: 6}
+
+
+def _f32(v):
+    return struct.unpack("<f", struct.pack("<f", v))[0]
+
+
+def _enc_int(value, key):                      # inverse of ((h-k)^k)
+    return (((value & 0xFFFFFFFF) ^ (key & 0xFFFFFFFF)) + key) & 0xFFFFFFFF
+
+
+def _enc_float(value, key):                    # inverse of float(key ^ byteswap12(h))
+    bits = struct.unpack("<I", struct.pack("<f", value))[0] ^ (key & 0xFFFFFFFF)
+    return (bits & 0xFF) | ((bits >> 16) & 0xFF) << 8 | ((bits >> 8) & 0xFF) << 16 | (bits & 0xFF000000)
+
+
+def _reader(heroes):
+    """MockReader laying out StageManager.HeroList -> HeroRuntime with the level/xp ciphers.
+    `heroes`: list of (hk, lvl_hidden, lvl_key, xp_hidden, xp_key) — RAW cipher words at the offsets."""
+    hl = 0x10000
+    mem = {SM + StageManager.HERO_LIST: hl, hl + Array.MAX_LENGTH: len(heroes)}
+    for i, (hk, lh, lk, xh, xk) in enumerate(heroes):
+        base = 0x100000 * (i + 1)
+        uf, hi = base + 0x1000, base + 0x2000
+        mem[hl + Array.DATA + i * 8] = base
+        mem[base + Unit.CACHE] = uf
+        mem[uf + HeroRuntime.INFO] = hi
+        mem[hi + HeroInfoData.HERO_KEY] = hk
+        mem[uf + HeroRuntime.LEVEL_HIDDEN] = lh
+        mem[uf + HeroRuntime.LEVEL_KEY] = lk
+        mem[uf + HeroRuntime.EXP_HIDDEN] = xh
+        mem[uf + HeroRuntime.EXP_KEY] = xk
+    return MockReader(mem=mem)
+
+
+def _synth(hk, level, exp, lkey, xkey):
+    """A hero whose level/exp are ENCODED from desired values (for behavior scenarios)."""
+    return (hk, _enc_int(level, lkey), lkey, _enc_float(exp, xkey), xkey)
+
+
+class TestDecodeWiringAgainstLiveGame:
+    """Real captured cipher words flow through read_live_party to the real level/xp (ground truth)."""
+
+    # heroKey -> (level cipher (hidden,key), xp cipher (hidden,key)) captured live on 1.00.20.
+    REAL = [
+        (101, 0x8C767E63, 0x463B3F0D, 0x38984737, 0x76EC4E86),   # Knight   Lv 91
+        (301, 0xD5E7E15E, 0x6AF3F0CA, 0x0088434D, 0x4D487400),   # Sorcerer Lv 94
+        (201, 0xCFB0DF75, 0x67D86FCD, 0x14CE4686, 0x46299F6C),   # Ranger   Lv 101 (cap)
+    ]
+
+    def test_read_live_party_returns_real_levels(self):
+        party = read_live_party(_reader(self.REAL), SM, HERO_CAT)
+        assert party[101][0] == 91
+        assert party[301][0] == 94
+        assert party[201][0] == 101
+
+    def test_read_live_party_returns_real_within_level_xp(self):
+        party = read_live_party(_reader(self.REAL), SM, HERO_CAT)
+        assert party[201][1] == pytest.approx(256_967_868_416.0, abs=1.0)   # Ranger == save (cap, frozen)
+        assert party[101][1] == pytest.approx(1_441_486_976.0, abs=1.0)     # Knight within-level xp
+        assert party[301][1] == pytest.approx(146_785_488.0, abs=1.0)       # Sorcerer within-level xp
+
+
+class TestDecodeRobustness:
+    """The bug class PR #75 ships: bit-31-set hidden/key. Our ru32 path decodes them; a signed
+    ri32 + struct.pack('<I') would raise -> None -> silent save fallback."""
+
+    def test_bit31_keys_decode_not_none(self):
+        for lkey, xkey in [(0x80000000, 0xFFFFFFFF), (0xDEADBEEF, 0xC0FFEE99), (0xFFFFFFFF, 0x80000001)]:
+            party = read_live_party(_reader([_synth(301, 94, _f32(156_000_000.0), lkey, xkey)]), SM, HERO_CAT)
+            assert party[301][0] == 94                                   # not None / not garbage
+            assert party[301][1] == pytest.approx(_f32(156_000_000.0))
+
+
+class TestPipelineBehavior:
+    """read_live_party -> PartyXpAccumulator: the per-run gain across death / revive / cap. Inputs are
+    constructed (can't die on command); the ASSERTION is the accumulator's real gain."""
+
+    def _feed(self, acc, heroes):
+        acc.update(read_live_party(_reader(heroes), SM, HERO_CAT))
+
+    def test_gain_banked_when_hero_dies(self):
+        acc = PartyXpAccumulator()
+        self._feed(acc, [_synth(301, 94, _f32(100_000_000.0), 0x1, 0x2)])
+        self._feed(acc, [_synth(301, 94, _f32(100_500_000.0), 0x1, 0x3)])   # +0.5M before death
+        self._feed(acc, [])                                                 # DEAD: gone from HeroList
+        self._feed(acc, [])                                                 # still dead -> banked
+        assert acc.gain(301) == pytest.approx(_f32(100_500_000.0) - _f32(100_000_000.0))
+
+    def test_gain_resumes_after_revive(self):
+        acc = PartyXpAccumulator()
+        self._feed(acc, [_synth(301, 94, _f32(100_000_000.0), 0x1, 0x2)])
+        self._feed(acc, [_synth(301, 94, _f32(100_500_000.0), 0x1, 0x3)])   # +0.5M before death
+        self._feed(acc, [])                                                 # dead
+        self._feed(acc, [_synth(301, 94, _f32(100_500_000.0), 0x1, 0x4)])   # revived (gained 0 dead)
+        self._feed(acc, [_synth(301, 94, _f32(101_000_000.0), 0x1, 0x5)])   # +0.5M after revive
+        assert acc.gain(301) == pytest.approx(_f32(101_000_000.0) - _f32(100_000_000.0))
+
+    def test_capped_hero_gains_zero(self, real_curve):
+        acc = PartyXpAccumulator()
+        for exp, xkey in zip([_f32(1e9), _f32(1.5e9), _f32(2e9)], [0x11, 0x80000000, 0xFFFFFFFF], strict=True):
+            self._feed(acc, [_synth(201, 101, exp, 0x7, xkey)])             # live level 101 = cap
+        assert acc.gain(201) == pytest.approx(0.0)                          # phantom xp suppressed
+
+
+class TestUnreadableCipherFallsBack:
+    def test_exp_none_and_level_from_save(self):
+        """Cipher offsets unmapped -> ru32 None -> exp None (honest save fallback downstream); level
+        falls back to the save snapshot (never a bogus 0)."""
+        hl = 0x10000
+        mem = {SM + StageManager.HERO_LIST: hl, hl + Array.MAX_LENGTH: 1,
+               hl + Array.DATA: 0x100000, 0x100000 + Unit.CACHE: 0x101000,
+               0x101000 + HeroRuntime.INFO: 0x102000, 0x102000 + HeroInfoData.HERO_KEY: 301}
+        party = read_live_party(MockReader(mem=mem), SM, HERO_CAT, save_heroes={301: (88, 5.0)})
+        assert party[301][0] == 88        # level from the save fallback
+        assert party[301][1] is None      # exp None -> accumulator skips -> close_run tags "save"

--- a/reader/tests/test_obscured.py
+++ b/reader/tests/test_obscured.py
@@ -1,0 +1,80 @@
+"""Tests for game/obscured.py — the ACTk Obscured decoders (algorithm read from the 1.00.20 binary).
+
+The CORRECTNESS PROOF is `TestDecodeAgainstLiveGame`: raw (hiddenValue, currentCryptoKey) words
+CAPTURED FROM THE RUNNING 1.00.20 GAME, decoded and checked against INDEPENDENT ground truth — the
+hero LEVEL read from the save by a separate path (91/94/101, 3/3 exact) and the within-level XP (the
+Ranger is at the cap so its XP is frozen → live == save EXACTLY; Knight/Sorcerer match the save
+magnitude). These are NOT round-trips of our own code — real input, independently-known output.
+
+`TestDecodeInvertsActkEncode` is a supplementary PROPERTY check (the decode inverts the
+ACTk-faithful encode across the value/key range, incl. bit-31-set words) — breadth the golden points
+can't cover. It is anchored by, never a substitute for, the golden vectors.
+"""
+
+import struct
+
+import pytest
+
+from game.obscured import decode_obscured_float, decode_obscured_int
+
+
+class TestDecodeAgainstLiveGame:
+    """Real cipher words from the running game (build fp 1.00.20-0x6a3a1c51-0x6977000) -> the real
+    level/xp. Ground truth is the SAVE (read by a different code path) — not our encode."""
+
+    def test_level_decodes_to_save_level(self):
+        # ObscuredInt level @ HeroRuntime+0xCC (hidden +0xD0, key +0xD4). == the save level.
+        assert decode_obscured_int(0x8C767E63, 0x463B3F0D) == 91     # Knight   (save Lv 91)
+        assert decode_obscured_int(0xD5E7E15E, 0x6AF3F0CA) == 94     # Sorcerer (save Lv 94)
+        assert decode_obscured_int(0xCFB0DF75, 0x67D86FCD) == 101    # Ranger   (save Lv 101, cap)
+
+    def test_within_level_xp_matches_save(self):
+        # ObscuredFloat xp @ HeroRuntime+0x10C (hidden +0x110, key +0x114).
+        # Ranger at the cap → xp FROZEN → live decode == save value EXACTLY (5+ sig figs).
+        assert decode_obscured_float(0x14CE4686, 0x46299F6C) == pytest.approx(256_967_868_416.0, abs=1.0)
+        # Knight/Sorcerer mid-level → right magnitude vs the (older) save snapshot.
+        assert decode_obscured_float(0x38984737, 0x76EC4E86) == pytest.approx(1_441_486_976.0, abs=1.0)  # save ~1.4536e9
+        assert decode_obscured_float(0x0088434D, 0x4D487400) == pytest.approx(146_785_488.0, abs=1.0)    # save ~1.5628e8
+
+    def test_within_level_xp_below_curve(self):
+        # an honest sanity tie-in: a non-capped hero's within-level xp must sit below its level's
+        # ExpForLevelUp. curve[91]≈1.67e9 / curve[94]≈1.774e9 (config/level_curve.json).
+        assert 0 < decode_obscured_float(0x38984737, 0x76EC4E86) < 1.67e9   # Knight Lv91
+        assert 0 < decode_obscured_float(0x0088434D, 0x4D487400) < 1.774e9  # Sorcerer Lv94
+
+
+class TestDecodeInvertsActkEncode:
+    """Property: the decode inverts the ACTk-faithful ENCODE for every value/key, including
+    bit-31-set words (where a signed `ri32` + `struct.pack('<I')` raises — the latent bug we avoid
+    by reading `ru32` + masking). Covers the bit-pattern range the 6 golden points can't."""
+
+    @staticmethod
+    def _enc_int(value, key):                  # inverse of ((h-k)^k): h = (value ^ key) + key
+        return (((value & 0xFFFFFFFF) ^ (key & 0xFFFFFFFF)) + key) & 0xFFFFFFFF
+
+    @staticmethod
+    def _enc_float(value, key):                # inverse of float(key ^ byteswap12(h))
+        bits = struct.unpack("<I", struct.pack("<f", value))[0] ^ (key & 0xFFFFFFFF)
+        return (bits & 0xFF) | ((bits >> 16) & 0xFF) << 8 | ((bits >> 8) & 0xFF) << 16 | (bits & 0xFF000000)
+
+    # keys incl. bit-31 set (0x80000000, 0xFFFFFFFF) and hidden words that go negative as int32
+    KEYS = (0, 1, 0x463B3F0D, 0x76EC4E86, 0x80000000, 0xDEADBEEF, 0xFFFFFFFF)
+
+    def test_int_round_trip(self):
+        for value in (0, 1, 91, 94, 101, 500, 123456, 2_000_000_000):
+            for key in self.KEYS:
+                assert decode_obscured_int(self._enc_int(value, key), key) == value, (value, hex(key))
+
+    def test_float_round_trip(self):
+        def f32(v):
+            return struct.unpack("<f", struct.pack("<f", v))[0]
+        for value in (f32(x) for x in (0.0, 1.0, 156_280_000.0, 1_453_570_000.0, 256_970_000_000.0)):
+            for key in self.KEYS:
+                assert decode_obscured_float(self._enc_float(value, key), key) == value, (value, hex(key))
+
+    def test_none_propagates_never_zero(self):
+        # a bad read (ru32 -> None) yields None so the caller degrades to SAVE, NEVER a bogus 0.
+        assert decode_obscured_int(None, 5) is None
+        assert decode_obscured_int(5, None) is None
+        assert decode_obscured_float(None, 5) is None
+        assert decode_obscured_float(5, None) is None

--- a/reader/tests/test_xp.py
+++ b/reader/tests/test_xp.py
@@ -265,6 +265,19 @@ class TestPartyXpAccumulator:
         assert rec["exp_start"] == pytest.approx(1000.0)
         assert rec["exp_end"] == pytest.approx(2500.0)       # raw observation keeps moving
 
+    def test_absent_tick_banks_gain_then_resumes_on_revive(self):
+        """Death/revive in the per-run gain: a hero that DROPS from the snapshot (dies) banks its
+        gain — nothing lost, nothing double-counted — and RESUMES from the banked baseline on revive.
+        The dead ticks (absent from the snapshot) move nothing; the revive tick continues."""
+        acc = PartyXpAccumulator()
+        acc.update({601: (10, 100.0)})           # deployed
+        acc.update({601: (10, 150.0)})           # +50 before death
+        acc.update({})                           # DEAD: absent from the snapshot
+        acc.update({})                           # still dead -> banked, no change
+        acc.update({601: (10, 150.0)})           # REVIVED (a dead hero gained 0 while dead)
+        acc.update({601: (10, 230.0)})           # +80 after revive
+        assert acc.gain(601) == pytest.approx(130.0)   # 50 + 80; nothing lost or double-counted
+
     def test_solo_capped_hero_total_zero_not_none(self, real_curve):
         """REGRESSION (production, meter v0.31.0 / game v1.00.11, player denny8126): SOLO
         runs with just one Ranger lv101 (cap) racked up ~39M xpGained EACH (e.g. run


### PR DESCRIPTION
## Problem

Game build **1.00.20** zeroed the PLAIN `HeroRuntime` EXP/level `fakeValue` decoy, so the reader degraded to the per-hero **SAVE** delta. The save only flushes on autosave (~100s), so the per-run delta jumps **~2×** when one write straddles two runs — the "exp varia / dobra" players reported (Crow, sam789, Klatzmeister, KozukiDesu). Gold was unaffected (its own live counter), which is why only XP looked wrong.

## Solution

Recover the live within-level XP + level by **decoding the ACTk Obscured cipher in place**. The algorithm was **read from `GameAssembly.dll`** (disasm of `op_Implicit`), not guessed — a plain `hidden^key` guess was **refuted live** (jittered ±5M):

- **ObscuredInt** level = `(hidden - key) ^ key`
- **ObscuredFloat** xp = `float32(key ^ byteswap_1_2(hidden))`

Read with `ru32` + masking (handles bit-31-set words; a signed `ri32` + `struct.pack('<I')` raises on them). `read_live_party` feeds the live exp to `PartyXpAccumulator` → `xp_source` returns to `"live"`. **LEVEL** falls back to the save on an unreadable cipher; **EXP** stays `None` on a bad read (honest LIVE→SAVE, never the stale save masquerading as live). The overlay per-hero live ETA revives too. Capped (lv101) heroes still gain **0** (phantom xp).

## Verification (live, 1.00.20)

- Levels decode **91 / 94 / 101 == save** (3/3 exact).
- Sorcerer gain **749K / 752K per run == 748K measured on screen**.
- Ranger (cap) xp **== save exactly** (frozen at the cap).

## Tests

- `test_obscured.py` — **golden vectors** (real captured game words → real save level/xp) + ACTk encode/decode property round-trip (incl. bit-31 keys).
- `test_live_xp_integration.py` — decode+wiring vs **real game words**, **death banks the gain**, **revive resumes**, **max-level = 0**, bit-31 robustness, unreadable → save.
- `test_xp.py` — accumulator death/revive unit test.
- `validate_live.py [xp-live]` — a **per-build ORACLE** (decoded level == save) so a future cipher/offset change **fails the ship gate loudly** — the "find it again on every update" tripwire.

All 508 reader tests pass; ruff clean.

## Supersedes #75

@erickmarx independently disassembled the **same float decode** — strong cross-confirmation. This PR adds: the **ObscuredInt level** decode too, the `ru32` fix (his `ri32` + `struct.pack('<I')` raises on bit-31-set words → silent save fallback on ~84% of reads), unit + integration **tests**, **live level** recovery, the **validate_live oracle**, and drops the unrelated `dps.py` change. Closing #75 in favor of this.
