### PR TITLE
feat(app): upload per-hero reader stats to the leaderboard

### DIFF
--- a/app/src/main/__tests__/share-payload.test.ts
+++ b/app/src/main/__tests__/share-payload.test.ts
@@ -41,6 +41,23 @@ function run(overrides: Partial<RunRecord> = {}): RunRecord {
   } as RunRecord;
 }
 
+// A complete RunHero, optionally carrying the reader's live FINAL stats.
+function hero(stats: Record<string, number>): RunRecord["heroes"][number] {
+  return { heroKey: 201, class: "Knight", classId: null, level: 80, exp: 0, skills: [], items: [], stats };
+}
+
+describe("buildPayload hero stats passthrough", () => {
+  it("forwards the reader's live FINAL stats when the run carries them", () => {
+    const payload = buildPayload(run({ heroes: [hero({ "1": 4184.82, "2": 1.11 })] }));
+    expect(payload.party[0]!.stats).toEqual({ "1": 4184.82, "2": 1.11 });
+  });
+
+  it("omits stats when the reader provided none — reverting the passthrough would fail here", () => {
+    const payload = buildPayload(run({ heroes: [hero({})] }));
+    expect(payload.party[0]!.stats).toBeUndefined();
+  });
+});
+
 describe("buildPayload endedAt", () => {
   it("converts the reader's epoch-seconds ts to epoch ms", () => {
     expect(buildPayload(run()).endedAt).toBe(1_750_000_000_000);

--- a/app/src/main/share.ts
+++ b/app/src/main/share.ts
@@ -78,9 +78,11 @@ interface IngestRunHero {
   skillLevels?: Record<string, number>;
   gear?: Record<string, IngestGearSlot>;
   runeKeys?: number[];
-  /** The reader's live FINAL stats, keyed by StatType id (e.g. "1" AttackDamage). These are
-   *  read 100% faithfully from game memory; the site displays them directly instead of
-   *  recomputing from the build (the recompute can't reproduce account-wide stats). */
+  /** The reader's live FINAL stats, keyed by StatType id (e.g. "1" AttackDamage). Read 100%
+   *  faithfully from game memory — the hero's OWN, UNBUFFED values (reader 0x18 FINAL_STATS;
+   *  party buffs like the Priest's Blessing of Might live only in the 0x20 dict). The site
+   *  displays them directly and re-applies party buffs itself when deriving Basic Attack DPS,
+   *  instead of recomputing from the build (the recompute can't reproduce account-wide stats). */
   stats?: Record<string, number>;
 }
 interface IngestRunBody {

--- a/app/src/main/share.ts
+++ b/app/src/main/share.ts
@@ -78,6 +78,10 @@ interface IngestRunHero {
   skillLevels?: Record<string, number>;
   gear?: Record<string, IngestGearSlot>;
   runeKeys?: number[];
+  /** The reader's live FINAL stats, keyed by StatType id (e.g. "1" AttackDamage). These are
+   *  read 100% faithfully from game memory; the site displays them directly instead of
+   *  recomputing from the build (the recompute can't reproduce account-wide stats). */
+  stats?: Record<string, number>;
 }
 interface IngestRunBody {
   externalId: string;
@@ -186,6 +190,9 @@ function mapHero(hero: RunHero): IngestRunHero {
   if (skillLevels && Object.keys(skillLevels).length > 0) out.skillLevels = skillLevels;
   const gear = mapGear(hero.items);
   if (gear) out.gear = gear;
+  // The reader's live FINAL stats (keyed by StatType id) — uploaded so the site can show the
+  // real in-game values instead of recomputing them from the build.
+  if (hero.stats && Object.keys(hero.stats).length > 0) out.stats = hero.stats;
   return out;
 }
 


### PR DESCRIPTION
## What
`mapHero` now includes the reader's live **FINAL stats** (`stats`, keyed by StatType id) in the run upload. Previously the upload dropped them, so the site had to recompute every stat from the build.

## Why
We audited the reader against the in-game status panel (authoritative `StatType` enum from the 1.00.21 dump + live probes): **the reader reads every stat 100% faithfully** — e.g. Priest AttackDamage `1919.5` ≈ panel `1920`; MaxHp/Armor exact; MovementSpeed `10.08` = panel `1008` (×100 display scale, not a read error).

The site's build-recompute, by contrast, **can't reproduce account-wide stats** — e.g. a Priest recomputes to ~0 DPS while the reader reads its real ATK. So the reader is the correct source of truth. This ships the data; the companion **tbh-wiki** PR consumes it (displays the uploaded stats + computes DPS from them instead of recomputing from the build).

## Scope
- Additive, backward-compatible: `stats` is optional on `IngestRunHero`; old readers/site ignore it.
- `RunHero.stats` is already populated by the reader — this just stops dropping it on upload.

## Checks
- `pnpm check` (eslint + tsc ×2) — green
- `pnpm test` — 753/753 green