### PR TITLE
feat(meter): mark a clear partial below 95% capture (was 80%)

### DIFF
--- a/app/src/main/__tests__/convert.test.ts
+++ b/app/src/main/__tests__/convert.test.ts
@@ -192,11 +192,25 @@ describe("convert — quality verdict", () => {
     expect(convert(rawRun({ run_outcome: "abandoned" })).quality).toBe("skipped");
   });
 
-  it("a success that captured <80% of the clear is partial (joined mid-run)", () => {
-    // clear_time 100, but measured (duration) only 50 -> 50% < 80%.
+  it("a success that captured <95% of the clear is partial (joined mid-run)", () => {
+    // clear_time 100, but measured (duration) only 50 -> 50% < 95%.
     const r = convert(rawRun({ clear_time: { ok: true, value: 100 }, duration: 50 }));
     expect(r.partial).toBe(true);
     expect(r.quality).toBe("partial");
+  });
+
+  it("a success that captured 94% of the clear is partial (just under the 95% bar)", () => {
+    // clear_time 100, measured 94 -> 94% < 95% -> partial. Boundary case for the 95% threshold.
+    const r = convert(rawRun({ clear_time: { ok: true, value: 100 }, duration: 94 }));
+    expect(r.partial).toBe(true);
+    expect(r.quality).toBe("partial");
+  });
+
+  it("a success that captured exactly 95% of the clear is NOT partial (at the bar, it counts)", () => {
+    // clear_time 100, measured 95 -> 95% is NOT < 95% -> counted. Boundary case for the 95% threshold.
+    const r = convert(rawRun({ clear_time: { ok: true, value: 100 }, duration: 95 }));
+    expect(r.partial).toBe(false);
+    expect(r.quality).toBe("counted");
   });
 
   it("a success with non-positive damage is ALWAYS partial (#163; covers short x-10)", () => {
@@ -207,7 +221,7 @@ describe("convert — quality verdict", () => {
     expect(r.quality).toBe("partial");
   });
 
-  it("a short x-10 with damage <80% of a >=30s clear is NOT mis-flagged partial (clear<30 guard)", () => {
+  it("a short x-10 with damage <95% of a >=30s clear is NOT mis-flagged partial (clear<30 guard)", () => {
     // clear_time 20 (< 30) so the first partial clause is gated off; damage > 0 so the second
     // clause does not fire -> a legitimate short boss clear counts.
     const r = convert(

--- a/app/src/main/converter/helpers.ts
+++ b/app/src/main/converter/helpers.ts
@@ -74,9 +74,14 @@ export function round(value: number, digits = 2): number {
 // display filter lives in settings.ts, PR6 — never conflate the two).
 // --------------------------------------------------------------------------- //
 
+/** Minimum fraction of the official clear time the meter must have captured for a `success` to count:
+ *  below this it joined too late and the totals are undercounts. MUST stay in sync with the reader's
+ *  `meter_windows.PARTIAL_CAPTURE_MIN` (same number on both sides — see run-lifecycle). */
+const PARTIAL_CAPTURE_MIN = 0.95;
+
 /** PARTIAL capture: the meter joined a run already in progress, so its totals are under-counted.
  *  Ported verbatim from the reader's `_is_partial` (now the converter's spec, run-lifecycle): a
- *  `success` run is partial when it captured < 80% of the official clear time (guarded at
+ *  `success` run is partial when it captured < 95% of the official clear time (guarded at
  *  clear_time >= 30 so a legitimately-short x-10 boss run is never mis-flagged) OR — the exception —
  *  a success with NON-POSITIVE damage, which is ALWAYS a lost capture (the game never clears a stage
  *  with no damage; covers the short x-10 case the first clause skips, #163). Note `<= 0`, not `== 0`.
@@ -88,7 +93,7 @@ export function isPartial(
   totalDamage: number,
 ): boolean {
   if (status !== "success") return false;
-  return (clearTime >= 30 && duration < clearTime * 0.8) || totalDamage <= 0;
+  return (clearTime >= 30 && duration < clearTime * PARTIAL_CAPTURE_MIN) || totalDamage <= 0;
 }
 
 /** SKIP: the run is real but does not count — below the duration floor (and not x-10). The reader

--- a/reader/docs/_index.md
+++ b/reader/docs/_index.md
@@ -36,7 +36,7 @@ How it works and how to maintain it: [README](README.md).
 
 - [[invariants/instance-selection]] — structural pick of the singleton (managers); avoids dead-list → runs that never close · `meter_windows.py`
 - [[invariants/schema-versioning]] — bump `RAW_SCHEMA_VERSION` (raw/<id>.json) + normalize app-side when adding a field; `SCHEMA_VERSION` is the frozen marker (11) of the legacy runs.jsonl · `meter_windows.py`
-- [[invariants/run-lifecycle]] — start via `LOG_LIST`; end by `StageClearLog`/`StageFailedLog`; skip <30s except `stage != 10`; partial = success + (<80% clear OR damage ≤ 0); boss box post-clear → pending-close · `meter_windows.py`
+- [[invariants/run-lifecycle]] — start via `LOG_LIST`; end by `StageClearLog`/`StageFailedLog`; skip <30s except `stage != 10`; partial = success + (<95% clear OR damage ≤ 0); boss box post-clear → pending-close · `meter_windows.py`
 - [[invariants/orchestration-purity]] — `meter_windows.py` is a thin orchestrator (zero inline reads outside the scaffolding); new metric/capture → `metrics/` or `game/` · `meter_windows.py`
 - [[invariants/offsets-single-source]] — offset/enum/stride → `config/offsets.py`; business rule (e.g. `COMBAT_SUBKEY`) → the logic module; `SCHEMA_VERSION` → `meter_windows.py` · `config/offsets.py`
 - [[invariants/rva-index-resolution]] — PRIMARY class resolution by `TypeDefIndex`+calib, gated by a name round-trip; the scan is FALLBACK; new class → `TARGETS` · `il2cpp/resolver.py`

--- a/reader/docs/invariants/run-lifecycle.md
+++ b/reader/docs/invariants/run-lifecycle.md
@@ -1,6 +1,6 @@
 ---
 type: invariant
-description: "Run lifecycle: the reader INFERS start/end from memory (LogManager's LOG_LIST grows; closes on StageClearLog/StageFailedLog matched by KLASS-POINTER) — boundary detection is ITS job — and emits EVERY run to raw/<id>.json. The skip (<30s exc. stage 10) and partial (success w/ capture <80% OR damage<=0) predicates became the accounting SPEC applied by the CONVERTER (app); the reader no longer drops (skip ≠ vanish). SUCCESS only delays the WRITE by PENDING_CLOSE_GRACE (pending-close) to absorb the boss box the game logs ~0.6s AFTER the clear — otherwise the chest landed in the NEXT run."
+description: "Run lifecycle: the reader INFERS start/end from memory (LogManager's LOG_LIST grows; closes on StageClearLog/StageFailedLog matched by KLASS-POINTER) — boundary detection is ITS job — and emits EVERY run to raw/<id>.json. The skip (<30s exc. stage 10) and partial (success w/ capture <95% OR damage<=0) predicates became the accounting SPEC applied by the CONVERTER (app); the reader no longer drops (skip ≠ vanish). SUCCESS only delays the WRITE by PENDING_CLOSE_GRACE (pending-close) to absorb the boss box the game logs ~0.6s AFTER the clear — otherwise the chest landed in the NEXT run."
 symptoms:
   - "run does not close"
   - "run does not appear"
@@ -21,6 +21,7 @@ code_anchors:
   - meter_windows.py::close_run
   - meter_windows.py::_should_skip_run
   - meter_windows.py::_is_partial
+  - meter_windows.py::PARTIAL_CAPTURE_MIN
   - meter_windows.py::PENDING_CLOSE_GRACE
   - meter_windows.py::TRAILING_BOX_TIERS
   - meter_windows.py::_new_pending
@@ -30,6 +31,7 @@ code_anchors:
   - meter_windows.py::_drop_counts
   - config/offsets.py::LogManager.LOG_LIST
 asserts:
+  - meter_windows.PARTIAL_CAPTURE_MIN == 0.95
   - meter_windows.PENDING_CLOSE_GRACE == 3.0
 guarded_by:
   - tests/test_run_lifecycle_predicates.py::TestShouldSkipRun::test_stage_x10_under_30s_is_kept
@@ -132,10 +134,15 @@ the summary/console. The real rule (which the converter ports) is:
 
 ```
 status == "success"  AND  (
-    (clear_time >= 30 AND measured < clear_time * 0.8)   # joined mid-run
-    OR total_damage <= 0                                  # success with no damage = lost capture
+    (clear_time >= 30 AND measured < clear_time * PARTIAL_CAPTURE_MIN)   # joined mid-run (<95%)
+    OR total_damage <= 0                                                 # success with no damage = lost capture
 )
 ```
+
+`PARTIAL_CAPTURE_MIN` is **0.95** — a clear counts only if the meter captured **≥95%** of it. The
+reader (`meter_windows.PARTIAL_CAPTURE_MIN`) and the converter
+(`app/src/main/converter/helpers.ts::PARTIAL_CAPTURE_MIN`) **MUST hold the same number**; the
+converter is the persisted spec, the reader only annotates `meter.log` / the `[run-close]` diag.
 
 Two points the skill drifted on that the TRUTH (the code + `tests/test_run_lifecycle_predicates.py`)
 contradicts:

--- a/reader/meter_windows.py
+++ b/reader/meter_windows.py
@@ -92,6 +92,11 @@ TRAILING_BOX_TIERS = (EMonsterLogType.Boss, EMonsterLogType.ActBoss)
 # bug); only the file WRITE is deferred. ACCEPTED trade-off: a hard kill (e.g. AV SIGKILL)
 # inside the window loses that record. See docs/invariants/run-lifecycle.
 PENDING_CLOSE_GRACE = 3.0
+# Minimum fraction of the official clear time the meter must have captured for a SUCCESS to count:
+# below this it joined too late and the totals are undercounts (partial). MUST stay in sync with the
+# converter's app/src/main/converter/helpers.ts::PARTIAL_CAPTURE_MIN (same number on both sides — the
+# reader only logs/diags `partial`; the converter is the persisted spec). See docs/invariants/run-lifecycle.
+PARTIAL_CAPTURE_MIN = 0.95
 
 GAME_VERSION = "1.00.21"   # FALLBACK: the GameAssembly.dll build the reader was made against; the INSTALLED version comes from the game's Version.txt (_detect_game_version)
 # raw/<id>.json: the LIVE format the reader emits (1 file per run). Bump ONLY when the SHAPE of the
@@ -491,12 +496,12 @@ def _should_skip_run(measured, clear_time, stage):
 
 
 def _is_partial(status, clear_time, measured, total_damage):
-    """PARTIAL capture: the meter joined a run already in progress (<80% of the official clear) ->
-    undercount. Gated on clear_time>=30 so x-10 runs (boss, seconds) aren't mis-flagged.
-    EXCEPTION: a success with measured damage <=0 is always a missed capture (covers x-10 with clear<30s
-    that skipped the check and pushed all-zeros to the leaderboard, #163)."""
+    """PARTIAL capture: the meter joined a run already in progress (< PARTIAL_CAPTURE_MIN of the
+    official clear, i.e. <95%) -> undercount. Gated on clear_time>=30 so x-10 runs (boss, seconds)
+    aren't mis-flagged. EXCEPTION: a success with measured damage <=0 is always a missed capture
+    (covers x-10 with clear<30s that skipped the check and pushed all-zeros to the leaderboard, #163)."""
     return bool(status == "success" and (
-        (clear_time >= 30 and measured < clear_time * 0.8) or total_damage <= 0))
+        (clear_time >= 30 and measured < clear_time * PARTIAL_CAPTURE_MIN) or total_damage <= 0))
 
 
 def _box_belongs_to_pending(mt, has_pending):
@@ -1026,7 +1031,7 @@ def run(hz, output_dir, debug=False):
             # gold_ok=False -> the envelope marks err and the converter degrades the run, honestly.
             gold_ok = save_delta is not None
             gold_gain, ge_src = (save_delta if gold_ok else 0), "save"
-        # PARTIAL capture: the meter joined a run already in progress (saw < 80% of the official clear) ->
+        # PARTIAL capture: the meter joined a run already in progress (saw < 95% of the official clear) ->
         # damage/gold/xp undercounted. An EXPLICIT flag so the app discards by the flag, instead of inferring
         # "partial" from gold==0 (which silently hid COMPLETE runs whenever the live gold read
         # failed). Only on a clear (clear_time = official duration); gated on >=30s so x-10 runs

--- a/reader/tests/test_run_lifecycle_predicates.py
+++ b/reader/tests/test_run_lifecycle_predicates.py
@@ -27,11 +27,16 @@ class TestIsPartial:
     def test_failure_is_never_partial(self):
         assert _is_partial("failed", clear_time=100, measured=50, total_damage=5000) is False
 
-    def test_full_clear_with_damage_is_not_partial(self):
+    def test_full_clear_at_95pct_with_damage_is_not_partial(self):
+        # measured == 95% of the official clear: NOT < 95% -> counts. Boundary case for PARTIAL_CAPTURE_MIN.
         assert _is_partial("success", clear_time=100, measured=95, total_damage=5000) is False
 
+    def test_just_under_95pct_is_partial(self):
+        # measured 94 of a 100s clear -> 94% < 95% -> partial. Boundary case for PARTIAL_CAPTURE_MIN.
+        assert _is_partial("success", clear_time=100, measured=94, total_damage=5000) is True
+
     def test_entered_late_is_partial(self):
-        # measured < 80% of the official clear (and clear >= 30) -> joined mid-run -> partial.
+        # measured < 95% of the official clear (and clear >= 30) -> joined mid-run -> partial.
         assert _is_partial("success", clear_time=100, measured=50, total_damage=5000) is True
 
     def test_short_clear_with_damage_is_not_partial(self):


### PR DESCRIPTION
## What
Raise the **partial-capture threshold from 80% → 95%**. A `success` run is flagged `partial` (stored, but filtered off the leaderboard) when the reader observed less than this fraction of the game-reported clear duration — i.e. it joined the run late and the totals undercount. Stricter integrity: a clear now counts only when **≥95%** of its duration was captured.

## Why
On the operator's runs, full clears measure **≥100%** of `clear_time` (the reader's wall-clock includes the inter-stage transition, e.g. `measured 77 / clear 75`), so 95% never false-flags a complete clear — it only newly catches runs the reader joined **5–20% late** (real undercounts that the old 80% bar let onto the leaderboard).

## How (only the ratio changes)
- Lift the bare ratio to a named constant **`PARTIAL_CAPTURE_MIN = 0.95`** on both sides — the converter's `isPartial` (**authoritative**: drives the record + leaderboard gate) and the reader's `_is_partial` (the `meter.log` / `reader-diag` mirror) — so they can't drift. A docs drift-test now pins the value.
- **Unchanged:** the `clear_time ≥ 30` guard (x-10 boss exemption), the `damage ≤ 0` clause, the 15s skip floor, the success-only gate, and the quality precedence.
- **Boundary:** a clear captured at **94% → partial**; at **≥95% → counts**.

## Verification (re-run locally, not just the agent's claim)
- `cd app && pnpm check` (eslint + tsc ×2) ✅ · `pnpm test` **757 passed** ✅
- `cd reader && ruff check .` ✅ · `python3 -m pytest` **512 passed** ✅ (incl. the docs drift-test pinning `PARTIAL_CAPTURE_MIN == 0.95`)

## Note for merge order
Touches `reader/meter_windows.py` and `reader/docs/invariants/run-lifecycle.md` in **different regions** than the reader clear-detection fix PR. They merge fine; whichever lands second just needs an "Update branch" (merge `main` in — no rebase/force).
