### PR TITLE
feat(app): distinct icon per run outcome in the runs list

### DIFF
--- a/app/src/renderer/src/lib/format.test.ts
+++ b/app/src/renderer/src/lib/format.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ago, formatEta, qualityBadge } from "./format";
+import { Bug, Skull, LogOut, CircleSlash, TimerOff } from "lucide-react";
+import { ago, formatEta, qualityBadge, runOutcomeBadge } from "./format";
+import type { RunStatus, RunQuality } from "../../../shared/run-types.js";
 
 describe("qualityBadge", () => {
   it("labels each non-counted verdict", () => {
@@ -26,6 +28,113 @@ describe("qualityBadge", () => {
 
   it("does not mark a legacy run with no verdict", () => {
     expect(qualityBadge(undefined)).toBeNull();
+  });
+});
+
+describe("runOutcomeBadge — one distinct marker per (status, quality)", () => {
+  // The marker is purely cosmetic; it must NOT mirror qualityBadge's collapse of fail+abandon into
+  // one "skipped" look. Each reason gets its own lucide icon + colour family.
+
+  it("maps a degraded run (bugged data) to Bug / rose, regardless of status", () => {
+    const badge = runOutcomeBadge("success", "degraded");
+    expect(badge?.Icon).toBe(Bug);
+    expect(badge?.iconClass).toBe("text-rose-400");
+    expect(badge?.rowClass).toBe("bg-rose-500/10");
+    expect(badge?.label).toBe("Bugged");
+    expect(badge?.title).toMatch(/leaderboard/i);
+  });
+
+  it("maps a wipe (status fail) to Skull / red", () => {
+    const badge = runOutcomeBadge("fail", "skipped");
+    expect(badge?.Icon).toBe(Skull);
+    expect(badge?.iconClass).toBe("text-red-400");
+    expect(badge?.rowClass).toBe("bg-red-500/10");
+    expect(badge?.label).toBe("Failed (wipe)");
+  });
+
+  it("maps an abandon (status abandoned) to LogOut / slate", () => {
+    const badge = runOutcomeBadge("abandoned", "skipped");
+    expect(badge?.Icon).toBe(LogOut);
+    expect(badge?.iconClass).toBe("text-slate-400");
+    expect(badge?.rowClass).toBe("bg-slate-500/10");
+    expect(badge?.label).toBe("Abandoned");
+  });
+
+  it("maps a partial success to CircleSlash / amber", () => {
+    const badge = runOutcomeBadge("success", "partial");
+    expect(badge?.Icon).toBe(CircleSlash);
+    expect(badge?.iconClass).toBe("text-amber-400");
+    expect(badge?.rowClass).toBe("bg-amber-500/10");
+    expect(badge?.label).toBe("Partial");
+  });
+
+  it("maps a too-short success (skipped) to TimerOff / zinc", () => {
+    const badge = runOutcomeBadge("success", "skipped");
+    expect(badge?.Icon).toBe(TimerOff);
+    expect(badge?.iconClass).toBe("text-zinc-400");
+    expect(badge?.rowClass).toBe("bg-zinc-500/10");
+    expect(badge?.label).toBe("Too short");
+  });
+
+  it("does not mark a clean counted success (no marker)", () => {
+    expect(runOutcomeBadge("success", "counted")).toBeNull();
+  });
+
+  it("does not mark a legacy success with no verdict", () => {
+    expect(runOutcomeBadge("success", undefined)).toBeNull();
+  });
+
+  // ── Precedence edges: bugged > fail > abandoned > partial > too-short ──
+
+  it("prefers bugged over the game outcome (degraded + fail → Bug, not Skull)", () => {
+    const badge = runOutcomeBadge("fail", "degraded");
+    expect(badge?.Icon).toBe(Bug);
+    expect(badge?.label).toBe("Bugged");
+  });
+
+  it("prefers bugged over an abandon (degraded + abandoned → Bug)", () => {
+    expect(runOutcomeBadge("abandoned", "degraded")?.Icon).toBe(Bug);
+  });
+
+  it("prefers the fail outcome over a partial verdict (fail + partial → Skull)", () => {
+    expect(runOutcomeBadge("fail", "partial")?.Icon).toBe(Skull);
+  });
+
+  it("prefers an abandon over a partial verdict (abandoned + partial → LogOut)", () => {
+    expect(runOutcomeBadge("abandoned", "partial")?.Icon).toBe(LogOut);
+  });
+
+  // A degraded fail/abandon still counts as bugged (data is the dominant reason); a non-degraded
+  // fail/abandon with a counted/undefined quality still marks by status (the run did not clear).
+  it("marks a fail/abandon even when quality is counted or undefined", () => {
+    expect(runOutcomeBadge("fail", "counted")?.Icon).toBe(Skull);
+    expect(runOutcomeBadge("fail", undefined)?.Icon).toBe(Skull);
+    expect(runOutcomeBadge("abandoned", "counted")?.Icon).toBe(LogOut);
+    expect(runOutcomeBadge("abandoned", undefined)?.Icon).toBe(LogOut);
+  });
+
+  it("gives every non-counted outcome a title mentioning the leaderboard", () => {
+    const combos: [RunStatus, RunQuality | undefined][] = [
+      ["success", "degraded"],
+      ["fail", "skipped"],
+      ["abandoned", "skipped"],
+      ["success", "partial"],
+      ["success", "skipped"],
+    ];
+    for (const [status, quality] of combos) {
+      expect(runOutcomeBadge(status, quality)?.title).toMatch(/leaderboard/i);
+    }
+  });
+
+  it("never reuses one icon for two different reasons (all five are distinct)", () => {
+    const icons = [
+      runOutcomeBadge("success", "degraded")?.Icon,
+      runOutcomeBadge("fail", "skipped")?.Icon,
+      runOutcomeBadge("abandoned", "skipped")?.Icon,
+      runOutcomeBadge("success", "partial")?.Icon,
+      runOutcomeBadge("success", "skipped")?.Icon,
+    ];
+    expect(new Set(icons).size).toBe(5);
   });
 });
 

--- a/app/src/renderer/src/lib/format.ts
+++ b/app/src/renderer/src/lib/format.ts
@@ -1,3 +1,4 @@
+import { Bug, Skull, LogOut, CircleSlash, TimerOff, type LucideIcon } from "lucide-react";
 import type { RunStatus, RunQuality } from "../../../shared/run-types.js";
 import { tFor, type Translate } from "../../../shared/i18n/index.js";
 
@@ -180,6 +181,111 @@ export function qualityBadge(
     iconClass: entry.iconClass,
     rowClass: entry.rowClass,
     noticeClass: entry.noticeClass,
+  };
+}
+
+/** The visual marker for a run that did NOT count, resolved from BOTH the game outcome (`status`)
+ *  and the converter's verdict (`quality`) so each reason reads distinctly — a wipe, an abandon, a
+ *  too-short clear, a partial capture, and a bugged read no longer collapse to one icon/colour. */
+export interface RunOutcomeBadge {
+  /** The lucide icon component for this outcome (rendered as `<badge.Icon … />`). */
+  Icon: LucideIcon;
+  /** Short, self-contained label for the SR hint + detail-banner heading. */
+  label: string;
+  /** Plain-language explanation shown on hover (list) and in the banner (detail). */
+  title: string;
+  /** Text colour for the marker icon in the runs list + detail banner. */
+  iconClass: string;
+  /** Background tint applied to the WHOLE runs-list row, so a non-counted run reads as set-apart. */
+  rowClass: string;
+  /** Border + tinted background + text for the detail-view banner container. */
+  noticeClass: string;
+}
+
+// One marker per run, picked by PRECEDENCE over (status, quality):
+//   bugged (degraded data) > failed (wipe) > abandoned > partial > too-short (skipped) > counted.
+// A clean counted clear (and a legacy run with no verdict) returns null = no marker. This is PURELY
+// COSMETIC — it mirrors, and never alters, the counting/hiding the `quality` verdict drives
+// (qualityBadge stays the source for those). Each entry's icon colour family matches its row tint
+// and banner triple; label/title are dict KEYS so the marker follows the app language.
+type OutcomeStyle = {
+  Icon: LucideIcon;
+  labelKey: Parameters<Translate>[0];
+  titleKey: Parameters<Translate>[0];
+  iconClass: string;
+  rowClass: string;
+  noticeClass: string;
+};
+const OUTCOME_BUGGED: OutcomeStyle = {
+  Icon: Bug,
+  labelKey: "outcome.buggedLabel",
+  titleKey: "outcome.buggedTitle",
+  iconClass: "text-rose-400",
+  rowClass: "bg-rose-500/10",
+  noticeClass: "border-rose-500/30 bg-rose-500/10 text-rose-200",
+};
+const OUTCOME_FAILED: OutcomeStyle = {
+  Icon: Skull,
+  labelKey: "outcome.failedLabel",
+  titleKey: "outcome.failedTitle",
+  iconClass: "text-red-400",
+  rowClass: "bg-red-500/10",
+  noticeClass: "border-red-500/30 bg-red-500/10 text-red-200",
+};
+const OUTCOME_ABANDONED: OutcomeStyle = {
+  Icon: LogOut,
+  labelKey: "outcome.abandonedLabel",
+  titleKey: "outcome.abandonedTitle",
+  iconClass: "text-slate-400",
+  rowClass: "bg-slate-500/10",
+  noticeClass: "border-slate-500/30 bg-slate-500/10 text-slate-200",
+};
+const OUTCOME_PARTIAL: OutcomeStyle = {
+  Icon: CircleSlash,
+  labelKey: "outcome.partialLabel",
+  titleKey: "outcome.partialTitle",
+  iconClass: "text-amber-400",
+  rowClass: "bg-amber-500/10",
+  noticeClass: "border-amber-500/30 bg-amber-500/10 text-amber-200",
+};
+const OUTCOME_TOO_SHORT: OutcomeStyle = {
+  Icon: TimerOff,
+  labelKey: "outcome.tooShortLabel",
+  titleKey: "outcome.tooShortTitle",
+  iconClass: "text-zinc-400",
+  rowClass: "bg-zinc-500/10",
+  noticeClass: "border-zinc-500/30 bg-zinc-500/10 text-zinc-200",
+};
+
+/** Pick the single outcome style for a run by precedence, or null when it is a clean counted clear
+ *  (or a legacy run with no verdict — both render unmarked). Bad data wins over the game outcome,
+ *  which wins over a partial capture, which wins over a too-short clear. */
+function outcomeStyle(status: RunStatus, quality: RunQuality | undefined): OutcomeStyle | null {
+  if (quality === "degraded") return OUTCOME_BUGGED;
+  if (status === "fail") return OUTCOME_FAILED;
+  if (status === "abandoned") return OUTCOME_ABANDONED;
+  if (quality === "partial") return OUTCOME_PARTIAL;
+  if (quality === "skipped") return OUTCOME_TOO_SHORT;
+  return null;
+}
+
+/** The outcome marker (icon + colour + label) for a run, or null for a clean counted clear. Reads
+ *  BOTH `status` and `quality` so a wipe, an abandon, a too-short clear, a partial capture and a
+ *  bugged read are visually distinct in the runs list and the detail banner. */
+export function runOutcomeBadge(
+  status: RunStatus,
+  quality: RunQuality | undefined,
+  t: Translate = tEn,
+): RunOutcomeBadge | null {
+  const style = outcomeStyle(status, quality);
+  if (!style) return null;
+  return {
+    Icon: style.Icon,
+    label: t(style.labelKey),
+    title: t(style.titleKey),
+    iconClass: style.iconClass,
+    rowClass: style.rowClass,
+    noticeClass: style.noticeClass,
   };
 }
 

--- a/app/src/renderer/src/views/RunDetailView.tsx
+++ b/app/src/renderer/src/views/RunDetailView.tsx
@@ -13,7 +13,6 @@ import {
   Loader2,
   Upload,
   Star,
-  AlertTriangle,
 } from "lucide-react";
 import type { RunRecord, RunStatus, RunQuality, RunHero } from "../../../shared/run-types.js";
 import type { AuthStatus } from "../../../shared/ipc-types.js";
@@ -25,7 +24,7 @@ import {
   formatDateTime,
   modeBadgeClass,
   modeLabel,
-  qualityBadge,
+  runOutcomeBadge,
 } from "~/lib/format";
 import { heroName } from "~/lib/game-data";
 import { useI18n } from "~/lib/i18n";
@@ -158,9 +157,9 @@ export function RunDetailView({ runId, onBack }: RunDetailViewProps) {
 
       {/* ── Body ────────────────────────────────────────────────────────────── */}
       <div className="flex-1 overflow-y-auto px-4 py-3">
-        {/* Quality notice — explains why a partial/degraded run's numbers can't be trusted and why
-            it isn't on the leaderboard, with the per-field read failures (issues) when present. */}
-        <QualityNotice quality={run.quality} issues={run.issues} />
+        {/* Outcome notice — explains why a non-counted run (wipe / abandon / too short / partial /
+            bugged) isn't on the leaderboard, with the per-field read failures (issues) when present. */}
+        <QualityNotice status={run.status} quality={run.quality} issues={run.issues} />
 
         {/* Run metrics */}
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-6">
@@ -342,27 +341,28 @@ function XpHeroRow({ hero, total, t }: { hero: RunHero; total: number; t: Transl
   );
 }
 
-/** Banner shown for a run the converter sealed as partial/degraded: the numbers are incomplete or
- *  unreliable, so the run never reached the leaderboard. For a degraded run, `issues` carries the
- *  per-field read failures (field → reason) — surfaced so the user can see exactly what was lost. */
+/** Banner shown for any run that did not count, labelled by its specific outcome (wipe / abandon /
+ *  too short / partial / bugged) so the reason is explicit — not just "invalid". For a degraded
+ *  (bugged) run, `issues` carries the per-field read failures (field → reason), surfaced so the user
+ *  can see exactly what was lost. Cosmetic only — it never gates the leaderboard or the display. */
 function QualityNotice({
+  status,
   quality,
   issues,
 }: {
+  status: RunStatus;
   quality: RunQuality | undefined;
   issues?: Record<string, string>;
 }) {
   const { t } = useI18n();
-  const badge = qualityBadge(quality, t);
+  const badge = runOutcomeBadge(status, quality, t);
   if (!badge) return null;
   const entries = issues ? Object.entries(issues) : [];
   return (
     <div className={cn("mb-3 rounded-lg border px-3 py-2.5", badge.noticeClass)}>
       <div className="flex items-center gap-2">
-        <AlertTriangle className={cn("size-4 shrink-0", badge.iconClass)} />
-        <span className="text-xs font-semibold">
-          {t("runs.flaggedRun", { label: badge.label })}
-        </span>
+        <badge.Icon className={cn("size-4 shrink-0", badge.iconClass)} />
+        <span className="text-xs font-semibold">{badge.label}</span>
       </div>
       <p className="mt-1 text-xs leading-relaxed opacity-90">{badge.title}</p>
       {entries.length > 0 && (

--- a/app/src/renderer/src/views/RunListView.tsx
+++ b/app/src/renderer/src/views/RunListView.tsx
@@ -13,7 +13,6 @@ import {
   Eye,
   EyeOff,
   Star,
-  AlertTriangle,
   X,
 } from "lucide-react";
 import type { RunIndexEntry, RunColumnConfig } from "../../../shared/ipc-types.js";
@@ -27,7 +26,7 @@ import {
   modeTextClass,
   modeLabel,
   statusLabel,
-  qualityBadge,
+  runOutcomeBadge,
 } from "~/lib/format";
 import { ChestDrops } from "~/components/ChestDrops";
 import { HeroPortrait } from "~/components/HeroPortrait";
@@ -117,10 +116,11 @@ const COLUMNS: RunColumn[] = [
     track: "8.5rem",
     cell: (r, { t }) => {
       // A run revealed by "show ignored" looks identical to a clean run in the table, so flag it
-      // with a warning icon next to the stage chip (the whole row is also tinted — see RunRow). The
-      // compact icon keeps the narrow column readable; the tooltip + detail-view banner carry the
-      // full reason.
-      const badge = qualityBadge(r.quality, t);
+      // with an outcome-specific icon next to the stage chip (the whole row is also tinted — see
+      // RunRow). The icon + colour say WHY it didn't count (wipe / abandon / too short / partial /
+      // bugged); the tooltip + detail-view banner carry the full reason. The compact icon keeps the
+      // narrow column readable.
+      const badge = runOutcomeBadge(r.status, r.quality, t);
       return (
         <span className="inline-flex min-w-0 items-center gap-1">
           {/* Stage + mode as one chip, like the web leaderboard's stage cell. */}
@@ -134,7 +134,7 @@ const COLUMNS: RunColumn[] = [
           </span>
           {badge && (
             <span title={badge.title} className="inline-flex shrink-0">
-              <AlertTriangle
+              <badge.Icon
                 aria-label={t("runs.flaggedRun", { label: badge.label })}
                 className={cn("size-3", badge.iconClass)}
               />
@@ -991,10 +991,11 @@ interface RunRowProps {
 }
 
 function RunRow({ run, cols, i18n, gridTemplateColumns, zebra, onSelect, onToggleFavorite }: RunRowProps) {
-  // Tint the whole row when the run did not count (red = invalid/unreliable, amber = partial). This
-  // is the at-a-glance "this is not a real run" signal; rowClass wins the bg conflict over zebra via
-  // tailwind-merge (last class), so an ignored run never reads as a normal striped row.
-  const rowClass = qualityBadge(run.quality)?.rowClass;
+  // Tint the whole row when the run did not count, in the outcome's colour family (red = wipe, slate
+  // = abandon, zinc = too short, amber = partial, rose = bugged). This is the at-a-glance "this is
+  // not a real run" signal; rowClass wins the bg conflict over zebra via tailwind-merge (last class),
+  // so an ignored run never reads as a normal striped row.
+  const rowClass = runOutcomeBadge(run.status, run.quality)?.rowClass;
   return (
     <div
       onClick={onSelect}

--- a/app/src/shared/i18n/de-de.ts
+++ b/app/src/shared/i18n/de-de.ts
@@ -240,6 +240,23 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "quality.skippedTitle":
     "Dieser Run ist kein gültiger Clear (zu kurz, oder er endete in Niederlage oder Abbruch) — er zählt nicht und wurde nicht zur Bestenliste hochgeladen.",
 
+  // ── Run-outcome marker (untranslated placeholders — English source until localized) ──
+  "outcome.buggedLabel": "Bugged",
+  "outcome.buggedTitle":
+    "Some values could not be read for this run, so the numbers may be wrong. It was not uploaded to the leaderboard.",
+  "outcome.failedLabel": "Failed (wipe)",
+  "outcome.failedTitle":
+    "The party was wiped before clearing the stage, so this run does not count and was not uploaded to the leaderboard.",
+  "outcome.abandonedLabel": "Abandoned",
+  "outcome.abandonedTitle":
+    "This run was left before the stage was cleared, so it does not count and was not uploaded to the leaderboard.",
+  "outcome.partialLabel": "Partial",
+  "outcome.partialTitle":
+    "The meter joined this run while it was already in progress, so its totals are under-counted. It was not uploaded to the leaderboard.",
+  "outcome.tooShortLabel": "Too short",
+  "outcome.tooShortTitle":
+    "This clear was below the minimum length to count, so it does not count and was not uploaded to the leaderboard.",
+
   // ── Blue-chest tracker ──
   "cooldowns.title": "Blautruhen-Tracker",
   "cooldowns.desc": "Erkennt Drops automatisch und verfolgt den Cooldown jeder Truhenstufe — ohne Klicks.",

--- a/app/src/shared/i18n/en-us.ts
+++ b/app/src/shared/i18n/en-us.ts
@@ -246,6 +246,25 @@ export const DICT = {
   "quality.skippedTitle":
     "This run is not a valid clear (too short, or it ended in a fail or abandon), so it does not count and was not uploaded to the leaderboard.",
 
+  // ── Run-outcome marker (the runs-list icon/tint + detail banner) — distinguishes WHY a run did
+  //    not count by combining status + quality, unlike the quality-only verdict copy above. Purely
+  //    cosmetic; it never changes which runs count, upload, or are hidden. ──
+  "outcome.buggedLabel": "Bugged",
+  "outcome.buggedTitle":
+    "Some values could not be read for this run, so the numbers may be wrong. It was not uploaded to the leaderboard.",
+  "outcome.failedLabel": "Failed (wipe)",
+  "outcome.failedTitle":
+    "The party was wiped before clearing the stage, so this run does not count and was not uploaded to the leaderboard.",
+  "outcome.abandonedLabel": "Abandoned",
+  "outcome.abandonedTitle":
+    "This run was left before the stage was cleared, so it does not count and was not uploaded to the leaderboard.",
+  "outcome.partialLabel": "Partial",
+  "outcome.partialTitle":
+    "The meter joined this run while it was already in progress, so its totals are under-counted. It was not uploaded to the leaderboard.",
+  "outcome.tooShortLabel": "Too short",
+  "outcome.tooShortTitle":
+    "This clear was below the minimum length to count, so it does not count and was not uploaded to the leaderboard.",
+
   // ── Blue-chest tracker ──
   "cooldowns.title": "Blue-chest tracker",
   "cooldowns.desc": "Auto-detects drops and tracks each chest level's cooldown — no clicks.",

--- a/app/src/shared/i18n/es-es.ts
+++ b/app/src/shared/i18n/es-es.ts
@@ -240,6 +240,23 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "quality.skippedTitle":
     "Esta run no es un clear válido (demasiado corta, o terminó en derrota o abandono), así que no cuenta y no se subió a la clasificación.",
 
+  // ── Run-outcome marker (untranslated placeholders — English source until localized) ──
+  "outcome.buggedLabel": "Bugged",
+  "outcome.buggedTitle":
+    "Some values could not be read for this run, so the numbers may be wrong. It was not uploaded to the leaderboard.",
+  "outcome.failedLabel": "Failed (wipe)",
+  "outcome.failedTitle":
+    "The party was wiped before clearing the stage, so this run does not count and was not uploaded to the leaderboard.",
+  "outcome.abandonedLabel": "Abandoned",
+  "outcome.abandonedTitle":
+    "This run was left before the stage was cleared, so it does not count and was not uploaded to the leaderboard.",
+  "outcome.partialLabel": "Partial",
+  "outcome.partialTitle":
+    "The meter joined this run while it was already in progress, so its totals are under-counted. It was not uploaded to the leaderboard.",
+  "outcome.tooShortLabel": "Too short",
+  "outcome.tooShortTitle":
+    "This clear was below the minimum length to count, so it does not count and was not uploaded to the leaderboard.",
+
   // ── Blue-chest tracker ──
   "cooldowns.title": "Tracker de cofre azul",
   "cooldowns.desc": "Detecta drops automáticamente y lleva el cooldown de cada nivel de cofre — sin clics.",

--- a/app/src/shared/i18n/fr-fr.ts
+++ b/app/src/shared/i18n/fr-fr.ts
@@ -239,6 +239,23 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "quality.skippedTitle":
     "Cette run n'est pas un clear valide (trop courte, ou terminée en défaite ou abandon), elle ne compte donc pas et n'a pas été envoyée au classement.",
 
+  // ── Run-outcome marker (untranslated placeholders — English source until localized) ──
+  "outcome.buggedLabel": "Bugged",
+  "outcome.buggedTitle":
+    "Some values could not be read for this run, so the numbers may be wrong. It was not uploaded to the leaderboard.",
+  "outcome.failedLabel": "Failed (wipe)",
+  "outcome.failedTitle":
+    "The party was wiped before clearing the stage, so this run does not count and was not uploaded to the leaderboard.",
+  "outcome.abandonedLabel": "Abandoned",
+  "outcome.abandonedTitle":
+    "This run was left before the stage was cleared, so it does not count and was not uploaded to the leaderboard.",
+  "outcome.partialLabel": "Partial",
+  "outcome.partialTitle":
+    "The meter joined this run while it was already in progress, so its totals are under-counted. It was not uploaded to the leaderboard.",
+  "outcome.tooShortLabel": "Too short",
+  "outcome.tooShortTitle":
+    "This clear was below the minimum length to count, so it does not count and was not uploaded to the leaderboard.",
+
   // ── Blue-chest tracker ──
   "cooldowns.title": "Tracker de coffre bleu",
   "cooldowns.desc": "Détecte les drops automatiquement et suit le cooldown de chaque niveau de coffre — sans clic.",

--- a/app/src/shared/i18n/id-id.ts
+++ b/app/src/shared/i18n/id-id.ts
@@ -239,6 +239,23 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "quality.skippedTitle":
     "Run ini bukan clear yang sah (terlalu pendek, atau berakhir gagal/ditinggalkan), jadi tidak dihitung dan tidak diunggah ke papan peringkat.",
 
+  // ── Run-outcome marker (untranslated placeholders — English source until localized) ──
+  "outcome.buggedLabel": "Bugged",
+  "outcome.buggedTitle":
+    "Some values could not be read for this run, so the numbers may be wrong. It was not uploaded to the leaderboard.",
+  "outcome.failedLabel": "Failed (wipe)",
+  "outcome.failedTitle":
+    "The party was wiped before clearing the stage, so this run does not count and was not uploaded to the leaderboard.",
+  "outcome.abandonedLabel": "Abandoned",
+  "outcome.abandonedTitle":
+    "This run was left before the stage was cleared, so it does not count and was not uploaded to the leaderboard.",
+  "outcome.partialLabel": "Partial",
+  "outcome.partialTitle":
+    "The meter joined this run while it was already in progress, so its totals are under-counted. It was not uploaded to the leaderboard.",
+  "outcome.tooShortLabel": "Too short",
+  "outcome.tooShortTitle":
+    "This clear was below the minimum length to count, so it does not count and was not uploaded to the leaderboard.",
+
   // ── Blue-chest tracker ──
   "cooldowns.title": "Tracker peti biru",
   "cooldowns.desc": "Mendeteksi drop otomatis dan memantau cooldown tiap level peti — tanpa klik.",

--- a/app/src/shared/i18n/ja-jp.ts
+++ b/app/src/shared/i18n/ja-jp.ts
@@ -239,6 +239,23 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "quality.skippedTitle":
     "このランは有効なクリアではありません（短すぎる、または失敗・放棄で終了）。カウントされず、リーダーボードにもアップロードされていません。",
 
+  // ── Run-outcome marker (untranslated placeholders — English source until localized) ──
+  "outcome.buggedLabel": "Bugged",
+  "outcome.buggedTitle":
+    "Some values could not be read for this run, so the numbers may be wrong. It was not uploaded to the leaderboard.",
+  "outcome.failedLabel": "Failed (wipe)",
+  "outcome.failedTitle":
+    "The party was wiped before clearing the stage, so this run does not count and was not uploaded to the leaderboard.",
+  "outcome.abandonedLabel": "Abandoned",
+  "outcome.abandonedTitle":
+    "This run was left before the stage was cleared, so it does not count and was not uploaded to the leaderboard.",
+  "outcome.partialLabel": "Partial",
+  "outcome.partialTitle":
+    "The meter joined this run while it was already in progress, so its totals are under-counted. It was not uploaded to the leaderboard.",
+  "outcome.tooShortLabel": "Too short",
+  "outcome.tooShortTitle":
+    "This clear was below the minimum length to count, so it does not count and was not uploaded to the leaderboard.",
+
   // ── Blue-chest tracker ──
   "cooldowns.title": "青宝箱トラッカー",
   "cooldowns.desc": "ドロップを自動検知して各レベルの宝箱のクールダウンを追跡 — クリック不要。",

--- a/app/src/shared/i18n/ko-kr.ts
+++ b/app/src/shared/i18n/ko-kr.ts
@@ -237,6 +237,23 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "quality.skippedTitle":
     "이 런은 유효한 클리어가 아닙니다 (너무 짧거나, 실패/포기로 끝남). 집계되지 않으며 리더보드에도 업로드되지 않았습니다.",
 
+  // ── Run-outcome marker (untranslated placeholders — English source until localized) ──
+  "outcome.buggedLabel": "Bugged",
+  "outcome.buggedTitle":
+    "Some values could not be read for this run, so the numbers may be wrong. It was not uploaded to the leaderboard.",
+  "outcome.failedLabel": "Failed (wipe)",
+  "outcome.failedTitle":
+    "The party was wiped before clearing the stage, so this run does not count and was not uploaded to the leaderboard.",
+  "outcome.abandonedLabel": "Abandoned",
+  "outcome.abandonedTitle":
+    "This run was left before the stage was cleared, so it does not count and was not uploaded to the leaderboard.",
+  "outcome.partialLabel": "Partial",
+  "outcome.partialTitle":
+    "The meter joined this run while it was already in progress, so its totals are under-counted. It was not uploaded to the leaderboard.",
+  "outcome.tooShortLabel": "Too short",
+  "outcome.tooShortTitle":
+    "This clear was below the minimum length to count, so it does not count and was not uploaded to the leaderboard.",
+
   // ── Blue-chest tracker ──
   "cooldowns.title": "파란 상자 트래커",
   "cooldowns.desc": "드롭을 자동 감지해 각 상자 레벨의 쿨다운을 추적합니다 — 클릭 없이.",

--- a/app/src/shared/i18n/pl-pl.ts
+++ b/app/src/shared/i18n/pl-pl.ts
@@ -240,6 +240,23 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "quality.skippedTitle":
     "To przejście nie jest ważnym ukończeniem (za krótkie, porażka albo porzucenie), więc się nie liczy i nie trafiło do rankingu.",
 
+  // ── Run-outcome marker (untranslated placeholders — English source until localized) ──
+  "outcome.buggedLabel": "Bugged",
+  "outcome.buggedTitle":
+    "Some values could not be read for this run, so the numbers may be wrong. It was not uploaded to the leaderboard.",
+  "outcome.failedLabel": "Failed (wipe)",
+  "outcome.failedTitle":
+    "The party was wiped before clearing the stage, so this run does not count and was not uploaded to the leaderboard.",
+  "outcome.abandonedLabel": "Abandoned",
+  "outcome.abandonedTitle":
+    "This run was left before the stage was cleared, so it does not count and was not uploaded to the leaderboard.",
+  "outcome.partialLabel": "Partial",
+  "outcome.partialTitle":
+    "The meter joined this run while it was already in progress, so its totals are under-counted. It was not uploaded to the leaderboard.",
+  "outcome.tooShortLabel": "Too short",
+  "outcome.tooShortTitle":
+    "This clear was below the minimum length to count, so it does not count and was not uploaded to the leaderboard.",
+
   // ── Blue-chest tracker ──
   "cooldowns.title": "Tracker niebieskiej skrzyni",
   "cooldowns.desc": "Automatycznie wykrywa dropy i śledzi cooldown każdego poziomu skrzyni — bez klikania.",

--- a/app/src/shared/i18n/pt-br.ts
+++ b/app/src/shared/i18n/pt-br.ts
@@ -238,6 +238,21 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "quality.skippedLabel": "Inválida",
   "quality.skippedTitle":
     "Esta run não é uma conclusão válida (curta demais, ou terminou em derrota ou abandono), então não conta e não foi enviada para o ranking.",
+  "outcome.buggedLabel": "Com bug",
+  "outcome.buggedTitle":
+    "Alguns valores não puderam ser lidos nesta run, então os números podem estar errados. Ela não foi enviada para o ranking.",
+  "outcome.failedLabel": "Derrota (wipe)",
+  "outcome.failedTitle":
+    "A party foi exterminada antes de concluir o estágio, então esta run não conta e não foi enviada para o ranking.",
+  "outcome.abandonedLabel": "Abandonada",
+  "outcome.abandonedTitle":
+    "Esta run foi deixada antes de o estágio ser concluído, então não conta e não foi enviada para o ranking.",
+  "outcome.partialLabel": "Parcial",
+  "outcome.partialTitle":
+    "O meter entrou nesta run com ela já em andamento, então os totais estão subcontados. Ela não foi enviada para o ranking.",
+  "outcome.tooShortLabel": "Curta demais",
+  "outcome.tooShortTitle":
+    "Esta conclusão ficou abaixo da duração mínima para contar, então não conta e não foi enviada para o ranking.",
 
   // ── Blue-chest tracker ──
   "cooldowns.title": "Tracker de baú azul",

--- a/app/src/shared/i18n/ru-ru.ts
+++ b/app/src/shared/i18n/ru-ru.ts
@@ -239,6 +239,23 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "quality.skippedTitle":
     "Это не валидное прохождение (слишком короткое, поражение или выход), поэтому забег не засчитан и не отправлен в таблицу лидеров.",
 
+  // ── Run-outcome marker (untranslated placeholders — English source until localized) ──
+  "outcome.buggedLabel": "Bugged",
+  "outcome.buggedTitle":
+    "Some values could not be read for this run, so the numbers may be wrong. It was not uploaded to the leaderboard.",
+  "outcome.failedLabel": "Failed (wipe)",
+  "outcome.failedTitle":
+    "The party was wiped before clearing the stage, so this run does not count and was not uploaded to the leaderboard.",
+  "outcome.abandonedLabel": "Abandoned",
+  "outcome.abandonedTitle":
+    "This run was left before the stage was cleared, so it does not count and was not uploaded to the leaderboard.",
+  "outcome.partialLabel": "Partial",
+  "outcome.partialTitle":
+    "The meter joined this run while it was already in progress, so its totals are under-counted. It was not uploaded to the leaderboard.",
+  "outcome.tooShortLabel": "Too short",
+  "outcome.tooShortTitle":
+    "This clear was below the minimum length to count, so it does not count and was not uploaded to the leaderboard.",
+
   // ── Blue-chest tracker ──
   "cooldowns.title": "Трекер синего сундука",
   "cooldowns.desc": "Автоматически замечает дропы и отслеживает кулдаун каждого уровня сундука — без кликов.",

--- a/app/src/shared/i18n/th-th.ts
+++ b/app/src/shared/i18n/th-th.ts
@@ -237,6 +237,23 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "quality.skippedTitle":
     "รันนี้ไม่ใช่การเคลียร์ที่ถูกต้อง (สั้นเกินไป หรือจบด้วยความล้มเหลว/ละทิ้ง) จึงไม่นับและไม่ถูกอัปโหลดขึ้นลีดเดอร์บอร์ด",
 
+  // ── Run-outcome marker (untranslated placeholders — English source until localized) ──
+  "outcome.buggedLabel": "Bugged",
+  "outcome.buggedTitle":
+    "Some values could not be read for this run, so the numbers may be wrong. It was not uploaded to the leaderboard.",
+  "outcome.failedLabel": "Failed (wipe)",
+  "outcome.failedTitle":
+    "The party was wiped before clearing the stage, so this run does not count and was not uploaded to the leaderboard.",
+  "outcome.abandonedLabel": "Abandoned",
+  "outcome.abandonedTitle":
+    "This run was left before the stage was cleared, so it does not count and was not uploaded to the leaderboard.",
+  "outcome.partialLabel": "Partial",
+  "outcome.partialTitle":
+    "The meter joined this run while it was already in progress, so its totals are under-counted. It was not uploaded to the leaderboard.",
+  "outcome.tooShortLabel": "Too short",
+  "outcome.tooShortTitle":
+    "This clear was below the minimum length to count, so it does not count and was not uploaded to the leaderboard.",
+
   // ── Blue-chest tracker ──
   "cooldowns.title": "ตัวติดตามกล่องฟ้า",
   "cooldowns.desc": "ตรวจจับดรอปอัตโนมัติและติดตามคูลดาวน์ของกล่องแต่ละเลเวล — ไม่ต้องคลิก",

--- a/app/src/shared/i18n/tr-tr.ts
+++ b/app/src/shared/i18n/tr-tr.ts
@@ -240,6 +240,23 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "quality.skippedTitle":
     "Bu run geçerli bir bitirme değil (çok kısa, ya da yenilgi veya terk ile bitti), bu yüzden sayılmaz ve lider tablosuna yüklenmedi.",
 
+  // ── Run-outcome marker (untranslated placeholders — English source until localized) ──
+  "outcome.buggedLabel": "Bugged",
+  "outcome.buggedTitle":
+    "Some values could not be read for this run, so the numbers may be wrong. It was not uploaded to the leaderboard.",
+  "outcome.failedLabel": "Failed (wipe)",
+  "outcome.failedTitle":
+    "The party was wiped before clearing the stage, so this run does not count and was not uploaded to the leaderboard.",
+  "outcome.abandonedLabel": "Abandoned",
+  "outcome.abandonedTitle":
+    "This run was left before the stage was cleared, so it does not count and was not uploaded to the leaderboard.",
+  "outcome.partialLabel": "Partial",
+  "outcome.partialTitle":
+    "The meter joined this run while it was already in progress, so its totals are under-counted. It was not uploaded to the leaderboard.",
+  "outcome.tooShortLabel": "Too short",
+  "outcome.tooShortTitle":
+    "This clear was below the minimum length to count, so it does not count and was not uploaded to the leaderboard.",
+
   // ── Blue-chest tracker ──
   "cooldowns.title": "Mavi sandık takipçisi",
   "cooldowns.desc": "Düşüşleri otomatik algılar ve her sandık seviyesinin bekleme süresini takip eder — tıklama yok.",

--- a/app/src/shared/i18n/uk-ua.ts
+++ b/app/src/shared/i18n/uk-ua.ts
@@ -240,6 +240,23 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "quality.skippedTitle":
     "Це не валідне проходження (закоротке, поразка або вихід), тому забіг не зараховано й не надіслано до таблиці лідерів.",
 
+  // ── Run-outcome marker (untranslated placeholders — English source until localized) ──
+  "outcome.buggedLabel": "Bugged",
+  "outcome.buggedTitle":
+    "Some values could not be read for this run, so the numbers may be wrong. It was not uploaded to the leaderboard.",
+  "outcome.failedLabel": "Failed (wipe)",
+  "outcome.failedTitle":
+    "The party was wiped before clearing the stage, so this run does not count and was not uploaded to the leaderboard.",
+  "outcome.abandonedLabel": "Abandoned",
+  "outcome.abandonedTitle":
+    "This run was left before the stage was cleared, so it does not count and was not uploaded to the leaderboard.",
+  "outcome.partialLabel": "Partial",
+  "outcome.partialTitle":
+    "The meter joined this run while it was already in progress, so its totals are under-counted. It was not uploaded to the leaderboard.",
+  "outcome.tooShortLabel": "Too short",
+  "outcome.tooShortTitle":
+    "This clear was below the minimum length to count, so it does not count and was not uploaded to the leaderboard.",
+
   // ── Blue-chest tracker ──
   "cooldowns.title": "Трекер синьої скрині",
   "cooldowns.desc": "Автоматично помічає дропи та відстежує кулдаун кожного рівня скрині — без кліків.",

--- a/app/src/shared/i18n/vi-vn.ts
+++ b/app/src/shared/i18n/vi-vn.ts
@@ -240,6 +240,23 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "quality.skippedTitle":
     "Lượt này không phải lần phá đảo hợp lệ (quá ngắn, hoặc kết thúc bằng thất bại/bỏ dở), nên không được tính và không tải lên bảng xếp hạng.",
 
+  // ── Run-outcome marker (untranslated placeholders — English source until localized) ──
+  "outcome.buggedLabel": "Bugged",
+  "outcome.buggedTitle":
+    "Some values could not be read for this run, so the numbers may be wrong. It was not uploaded to the leaderboard.",
+  "outcome.failedLabel": "Failed (wipe)",
+  "outcome.failedTitle":
+    "The party was wiped before clearing the stage, so this run does not count and was not uploaded to the leaderboard.",
+  "outcome.abandonedLabel": "Abandoned",
+  "outcome.abandonedTitle":
+    "This run was left before the stage was cleared, so it does not count and was not uploaded to the leaderboard.",
+  "outcome.partialLabel": "Partial",
+  "outcome.partialTitle":
+    "The meter joined this run while it was already in progress, so its totals are under-counted. It was not uploaded to the leaderboard.",
+  "outcome.tooShortLabel": "Too short",
+  "outcome.tooShortTitle":
+    "This clear was below the minimum length to count, so it does not count and was not uploaded to the leaderboard.",
+
   // ── Blue-chest tracker ──
   "cooldowns.title": "Theo dõi rương xanh",
   "cooldowns.desc": "Tự phát hiện đồ rơi và theo dõi thời gian hồi từng cấp rương — không cần bấm gì.",

--- a/app/src/shared/i18n/zh-hans.ts
+++ b/app/src/shared/i18n/zh-hans.ts
@@ -233,6 +233,23 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "quality.skippedTitle":
     "该挑战不是有效通关（太短，或以失败/放弃结束），因此不计入，也未上传到排行榜。",
 
+  // ── Run-outcome marker (untranslated placeholders — English source until localized) ──
+  "outcome.buggedLabel": "Bugged",
+  "outcome.buggedTitle":
+    "Some values could not be read for this run, so the numbers may be wrong. It was not uploaded to the leaderboard.",
+  "outcome.failedLabel": "Failed (wipe)",
+  "outcome.failedTitle":
+    "The party was wiped before clearing the stage, so this run does not count and was not uploaded to the leaderboard.",
+  "outcome.abandonedLabel": "Abandoned",
+  "outcome.abandonedTitle":
+    "This run was left before the stage was cleared, so it does not count and was not uploaded to the leaderboard.",
+  "outcome.partialLabel": "Partial",
+  "outcome.partialTitle":
+    "The meter joined this run while it was already in progress, so its totals are under-counted. It was not uploaded to the leaderboard.",
+  "outcome.tooShortLabel": "Too short",
+  "outcome.tooShortTitle":
+    "This clear was below the minimum length to count, so it does not count and was not uploaded to the leaderboard.",
+
   // ── Blue-chest tracker ──
   "cooldowns.title": "蓝宝箱追踪器",
   "cooldowns.desc": "自动检测掉落并追踪每个宝箱等级的冷却时间 — 无需点击。",

--- a/app/src/shared/i18n/zh-hant.ts
+++ b/app/src/shared/i18n/zh-hant.ts
@@ -233,6 +233,23 @@ export const DICT: Partial<Record<DictKey, string>> = {
   "quality.skippedTitle":
     "該挑戰不是有效通關（太短，或以失敗/放棄結束），因此不計入，也未上傳到排行榜。",
 
+  // ── Run-outcome marker (untranslated placeholders — English source until localized) ──
+  "outcome.buggedLabel": "Bugged",
+  "outcome.buggedTitle":
+    "Some values could not be read for this run, so the numbers may be wrong. It was not uploaded to the leaderboard.",
+  "outcome.failedLabel": "Failed (wipe)",
+  "outcome.failedTitle":
+    "The party was wiped before clearing the stage, so this run does not count and was not uploaded to the leaderboard.",
+  "outcome.abandonedLabel": "Abandoned",
+  "outcome.abandonedTitle":
+    "This run was left before the stage was cleared, so it does not count and was not uploaded to the leaderboard.",
+  "outcome.partialLabel": "Partial",
+  "outcome.partialTitle":
+    "The meter joined this run while it was already in progress, so its totals are under-counted. It was not uploaded to the leaderboard.",
+  "outcome.tooShortLabel": "Too short",
+  "outcome.tooShortTitle":
+    "This clear was below the minimum length to count, so it does not count and was not uploaded to the leaderboard.",
+
   // ── Blue-chest tracker ──
   "cooldowns.title": "藍寶箱追蹤器",
   "cooldowns.desc": "自動偵測掉落並追蹤每個寶箱等級的冷卻時間 — 無需點擊。",


### PR DESCRIPTION
## What
Each non-counted run now shows a **distinct icon + row tint by its real reason**, instead of one shared warning marker. Before, `fail` and `abandoned` both collapsed to `quality:"skipped"` → identical icon, so you couldn't tell a wipe from a walk-away.

One marker per run, by precedence **degraded > fail > abandoned > partial > too-short > counted**:

| Outcome | Icon (lucide) | Color | Counts? |
|---|---|---|---|
| clean clear | — (none) | — | ✅ |
| partial (<95% capture) | `CircleSlash` | amber | no |
| fail (wipe) | `Skull` | red | no |
| abandoned | `LogOut` | slate | no |
| bugged (data unreadable) | `Bug` | rose | no |
| too short (<15s) | `TimerOff` | zinc | no |

## Screenshots (seeded, one run per outcome)
**The five distinct icons** (+ a clean control row, no marker):

![run-outcome icons](https://github.com/mad-labs-org/tbh-meter/raw/063cdb9adfffc28028f02d015d337fa72fbeb7b4/run-outcome-icons/icons-zoom.png)

<details><summary>Full list (row tints) + detail-view banner</summary>

![list](https://github.com/mad-labs-org/tbh-meter/raw/063cdb9adfffc28028f02d015d337fa72fbeb7b4/run-outcome-icons/list.png)
![detail banner](https://github.com/mad-labs-org/tbh-meter/raw/063cdb9adfffc28028f02d015d337fa72fbeb7b4/run-outcome-icons/detail-banner.png)

</details>

## How
- New `runOutcomeBadge(status, quality)` in `format.ts` derives the marker from **both** the game outcome and the quality verdict. The existing `qualityBadge` (which drives **counting/hiding**) is **untouched** → this is **purely cosmetic**: nothing changes about which runs count, upload, or are hidden.
- Wired into the runs list (stage-chip marker + row tint) and the detail-view banner.
- i18n: 10 new `outcome.*` keys — **en-us + pt-br translated**, the other 14 locales English-placeholdered (the suite requires every key in every locale; runtime falls back to English).

## Verification (re-run locally)
- `pnpm check` (eslint + tsc ×2) ✅ · `pnpm test` **769 passed** ✅ (14 new `runOutcomeBadge` cases covering every (status, quality) combo + all precedence edges)
- Visual: rendered on real pixels (macOS ListApp), the 5 icons + tints above; DOM-confirmed classes (`lucide-skull text-red-400`, `lucide-bug text-rose-400`, …).

Independent of #83 (partial-95) and the reader clear-detection PR — different files, no conflict.
