### PR TITLE
fix(reader): keep detecting stage clears after the log list saturates

### DIFF
--- a/reader/docs/invariants/log-event-detection.md
+++ b/reader/docs/invariants/log-event-detection.md
@@ -16,6 +16,7 @@ code_anchors:
   - meter_windows.py::TARGETS
   - meter_windows.py::run
   - meter_windows.py::BOX_KEY_BY_TIER
+  - meter_windows.py::LogScanCursor
   - config/offsets.py::GetBoxLog
   - config/offsets.py::ELogType
   - metrics/events.py::EventFeed
@@ -25,15 +26,24 @@ guarded_by:
   - tests/test_meter_windows.py::TestBoxKeyByTier::test_three_tiers_map_to_canonical_box_keys
   - tests/test_meter_windows.py::TestSuffixInt::test_no_numeric_suffix
   - tests/test_events.py::TestEventFeed::test_first_update_is_baseline_no_events
+  - tests/test_log_scan.py::TestCapRotation::test_repeated_rotation_each_new_tail_detected_once
 ---
 
 # Log event detection (by klass-pointer, not by ELogType)
 
 `LogManager` keeps a `List<LogData>` (`LogManager.LOG_LIST`) where the game pushes **one
 entry per event** — stage end (success/failure), box drop, hero death/revive. The loop
-in `run` reads the new entries from the **previous `size` to the current one** each tick and
-decides what each one is. Each `LogData` is a managed object, so its **first field (offset 0) is the
-pointer to the Il2CppClass** — the "K-class" of the log's concrete type.
+in `run` asks `LogScanCursor` for the **new entries** each tick and decides what each one is.
+Each `LogData` is a managed object, so its **first field (offset 0) is the pointer to the
+Il2CppClass** — the "K-class" of the log's concrete type — which is also the cursor's stable
+**identity** for that entry.
+
+The list is **capped at 2000** and evicts from the HEAD when full, so a `[previous_size, size)`
+absolute-index scan desyncs once the cap saturates (it stops firing — every event then missed; see
+the boundary section of [[invariants/run-lifecycle]]). `LogScanCursor` therefore tracks the
+last-processed entry by its **object pointer**, scanning the tail backward and stopping at the first
+already-seen pointer — rotation-aware, immune to head-eviction. Detection (which entries are new) is
+the cursor's job; **labeling** (what each one is) is the klass-pointer comparison below.
 
 **The hard rule: the event type is decided by KLASS-POINTER EQUALITY, never by a type
 field.** The loop does `kl = reader.rptr(e)` (the entry's klass) and compares `kl == sc_class`,
@@ -77,9 +87,12 @@ success, not to the run the close just opened — see [[invariants/run-lifecycle
 
 `metrics.events.EventFeed` is independent of the labeling loop above: it only counts **how many new
 entries** appeared (delta of `size`, re-anchoring when the list truncates), without looking at any
-type. It is not the event-detection path — it is a counter. **Labeling** (knowing WHICH event it is)
-requires the klass-pointer, as described above; the "read each event's type" TODO in the `events.py`
-header was resolved in the `run` loop precisely by klass-pointer, not by dumping the `ELogType` field.
+type. It is not the event-detection path — it is a counter, and its size-delta is NOT how the run-close
+path survives the 2000-cap: that path uses `LogScanCursor` (pointer identity, above), because a
+size-delta on a head-evicting list pinned at the cap reads zero new entries and misses the clear.
+**Labeling** (knowing WHICH event it is) requires the klass-pointer, as described above; the "read each
+event's type" TODO in the `events.py` header was resolved in the `run` loop precisely by klass-pointer,
+not by dumping the `ELogType` field.
 
 ## Related
 - [[invariants/offsets-single-source]]

--- a/reader/docs/invariants/run-lifecycle.md
+++ b/reader/docs/invariants/run-lifecycle.md
@@ -28,6 +28,7 @@ code_anchors:
   - meter_windows.py::_box_belongs_to_pending
   - meter_windows.py::_absorb_drop
   - meter_windows.py::_drop_counts
+  - meter_windows.py::LogScanCursor
   - config/offsets.py::LogManager.LOG_LIST
 asserts:
   - meter_windows.PENDING_CLOSE_GRACE == 3.0
@@ -38,6 +39,8 @@ guarded_by:
   - tests/test_meter_windows.py::TestNewPending::test_deadline_is_now_plus_grace
   - tests/test_meter_windows.py::TestFlushPendingRec::test_flushed_json_contains_absorbed_boxes
   - tests/test_raw_record.py::test_absorbed_boss_box_lands_inside_drops_envelope_without_shape_change
+  - tests/test_log_scan.py::TestCapRotation::test_rotation_with_size_pinned_detects_new_tail_entry
+  - tests/test_log_scan.py::TestClearThenBoxOrderingAcrossRotation::test_clear_then_box_separate_rotated_ticks
 ---
 
 # Run lifecycle
@@ -45,13 +48,27 @@ guarded_by:
 A **run** is one stage attempt. The reader gets no "started/ended" event: it
 **infers the lifecycle from memory**, watching the game's log list every tick.
 
-## Boundary: LogManager's LOG_LIST grows
+## Boundary: new LogManager.LOG_LIST entries (tracked by OBJECT POINTER, rotation-aware)
 
-Each tick the loop reads the list's `size` at `LogManager.LOG_LIST` (the "bible" `offsets.py`
-marks this offset as the *run boundary*). When `size` **grows**, the reader scans only the
-NEW entries (`[last_size, size)`) and looks at each one's **klass-pointer** (the entry's first
-qword = pointer to its class). It's this growth that carries the terminal events — there is no
-separate "start" signal: the next run simply begins when the previous one closes.
+Each tick the loop reads `LogManager.LOG_LIST` (the "bible" `offsets.py` marks this offset as the
+*run boundary*) and asks `LogScanCursor` for the **NEW entries** since the previous tick; it then
+looks at each one's **klass-pointer** (the entry's first qword = pointer to its class). These new
+entries carry the terminal events — there is no separate "start" signal: the next run simply begins
+when the previous one closes.
+
+**Identity is the entry's OBJECT POINTER, never its index.** The list is **capped at 2000** (see
+[[invariants/log-event-detection]] / `metrics/events.py`); once full the game evicts from the **HEAD**
+to stay at the cap, so absolute indices shift DOWN on every append. The original absolute-index cursor
+(`[last_size, size)`, fired only while `size` grew) desynced PERMANENTLY at saturation: with `size`
+pinned at the cap it never fired again, so every `StageClearLog` was missed — runs closed only via the
+`abandoned` path (`clear_time=0`) and one open run accrued several stages (live `mobs` far above the
+stage total). A reader/game **restart did NOT fix it** (the game process keeps the saturated list; an
+index cursor just re-seeds to the cap). `LogScanCursor` instead tracks the last-processed entry by its
+heap pointer: each tick it scans the tail backward, collecting unseen pointers and stopping at the first
+already-seen one (bounded per tick by the scan cap), so head-eviction can't desync it and a tail append
+is detected even when `size` never changes. `seed()` establishes the baseline at attach/re-attach
+WITHOUT replaying the pre-existing backlog. The cursor yields **oldest→newest**, which is what the
+pending-close below relies on (the `StageClearLog` is processed BEFORE its trailing boss `GetBoxLog`).
 
 ## End: StageClearLog (success) / StageFailedLog (fail) by klass-pointer
 

--- a/reader/meter_windows.py
+++ b/reader/meter_windows.py
@@ -483,6 +483,92 @@ def _pick_list_singleton(reader, cands, list_off, cap):
                      reader.ri32((reader.rptr(a + list_off) or 0) + List.SIZE))), None)
 
 
+# Per-tick scan cap for the LOG_LIST tail (was the inline min(size, last_size+300)): at 10Hz
+# the game never appends this many log entries between ticks; a pathological burst beyond it
+# stops at the cap (a documented, pre-existing exposure — same as the old absolute-index cap).
+LOG_SCAN_CAP = 300
+
+
+class LogScanCursor:
+    """Rotation-aware detector of NEW LogManager.LOG_LIST entries (the run-close boundary).
+
+    The list is CAPPED at 2000 (see metrics/events.py); once full the game evicts from the HEAD
+    to stay at the cap, so ABSOLUTE indices shift DOWN every append. An absolute-index cursor
+    (`[last_size, size)`, fired only on `size` growing) desyncs PERMANENTLY at saturation: `size`
+    stops growing, the scan never runs, and every StageClearLog is missed → runs close only as
+    'abandoned' (clear_time=0) and one open run accrues several stages. So identity here is the
+    entry's OBJECT POINTER (the value in the list slot — each LogData is a managed object whose
+    first qword is its klass), NEVER its index: head-eviction can't desync it.
+
+    Mechanism (stop-at-first-seen backward scan): each tick scan the tail from `size-1` downward,
+    collecting unseen pointers, STOPPING at the first already-seen pointer (or after `cap` reads,
+    or index 0). The list only grows at the tail and evicts at the head, so the seen pointers
+    always form a contiguous block ending at the previous tail — the first seen pointer hit going
+    back is the true boundary; everything older is already processed. Normal append-only ticks
+    read just the 0..few new entries before hitting the boundary; a cap-saturated rotation reads
+    exactly the appended tail. `seed()` establishes the baseline at attach/re-resolve WITHOUT
+    replaying the backlog (the old `last_size = current size`). The seen-set is a bounded FIFO
+    (capacity ~2x the scan cap) so a pointer is remembered well past the visible window before it
+    ages out, guarding the dedup; pointer-address reuse within that window is treated as negligible
+    (same class of accepted imperfection as EventFeed's truncation re-anchor). Pure: it owns only
+    identity state and reads pointers through the caller's `read_ptr_at(i)` (None on a bad slot),
+    so meter_windows.py stays a thin orchestrator and the whole thing is unit-testable with a
+    fake list. See docs/invariants/run-lifecycle + docs/invariants/log-event-detection."""
+
+    def __init__(self):
+        self._seen = {}            # insertion-ordered FIFO of recently-processed entry pointers
+        self._anchored = False
+
+    def _cap_seen(self, cap):
+        # Keep the seen-set >= the visible window so a still-visible entry is never forgotten and
+        # re-yielded; FIFO-trim the oldest beyond that bound (a generous 2x cap).
+        limit = max(1, cap) * 2
+        while len(self._seen) > limit:
+            self._seen.pop(next(iter(self._seen)))
+
+    def _mark(self, ptr):
+        # most-recent insertion order: refresh position so a re-seen tail pointer doesn't age out.
+        if ptr in self._seen:
+            del self._seen[ptr]
+        self._seen[ptr] = True
+
+    def seed(self, read_ptr_at, size, cap):
+        """Baseline at attach/re-resolve: record the current tail as seen WITHOUT yielding it
+        (skip the pre-existing backlog — replacing `last_size = current size`)."""
+        self._anchored = True
+        n = size or 0
+        for i in range(n - 1, max(-1, n - 1 - max(1, cap)), -1):
+            e = read_ptr_at(i)
+            if e:
+                self._mark(e)
+        self._cap_seen(cap)
+
+    def new_entries(self, read_ptr_at, size, cap):
+        """The NEW entry pointers since the last call, oldest->newest, marked seen. Scans the tail
+        backward, stops at the first already-seen pointer (or cap reads / index 0). Falsy slots
+        (None/0 from a bad read) are skipped — never collected, never raising."""
+        if not self._anchored:
+            # defensive: a first call without an explicit seed must NOT replay the backlog.
+            self.seed(read_ptr_at, size, cap)
+            return []
+        if not size or size <= 0:
+            return []
+        out = []
+        lo = max(-1, size - 1 - max(1, cap))     # bound the per-tick scan (cap reads)
+        for i in range(size - 1, lo, -1):
+            e = read_ptr_at(i)
+            if not e:
+                continue                          # bad/empty slot: skip (exception-safety)
+            if e in self._seen:
+                break                             # boundary: everything older is already processed
+            out.append(e)
+        out.reverse()                             # oldest -> newest (chronological processing order)
+        for e in out:
+            self._mark(e)
+        self._cap_seen(cap)
+        return out
+
+
 def _should_skip_run(measured, clear_time, stage):
     """A run under 30s does NOT count (discarded) — EXCEPT stage x-10 (boss-only fight, can
     last seconds), which always counts. `stage` is the stage NUMBER (StageNo), NOT an
@@ -948,8 +1034,22 @@ def run(hz, output_dir, debug=False):
 
     R = new_run()
     # run_num is NOT reset here — it's resumed from resume_session (above) so as not to recycle an id.
-    _ll0 = reader.rptr(lm + LogManager.LOG_LIST)
-    last_size = (reader.ri32(_ll0 + List.SIZE) or 0) if _ll0 else 0
+
+    def _loglist_size_reader():
+        # (read_ptr_at, size) for the CURRENT LogManager.LOG_LIST tail. read_ptr_at(i) = the entry
+        # OBJECT pointer at absolute index i (the slot's value), None on a bad read — the identity
+        # the rotation-aware LogScanCursor tracks instead of the (head-evicting) absolute index.
+        ll = reader.rptr(lm + LogManager.LOG_LIST)
+        size = reader.ri32(ll + List.SIZE) if ll else None
+        items = reader.rptr(ll + List.ITEMS) if ll else None
+        return (lambda i: reader.rptr(items + Array.DATA + i * 8) if items else None), size
+
+    # Run-close boundary detection: the LOG_LIST is capped at 2000 and evicts from the HEAD once
+    # full, so absolute indices desync; the cursor tracks NEW entries by OBJECT POINTER. SEED here
+    # (and on re-attach) skips the pre-existing backlog (the old `last_size = current size`).
+    log_cursor = LogScanCursor()
+    _seed_read, _seed_size = _loglist_size_reader()
+    log_cursor.seed(_seed_read, _seed_size, LOG_SCAN_CAP)
     last_alive = 0
     prev_dead = None    # previous DeadMonsterUnit size (to detect a stage reload)
     dead_reads = 0      # consecutive failing reads = game closed/restarted (re-attach)
@@ -1266,8 +1366,11 @@ def run(hz, output_dir, debug=False):
                                 else:
                                     tbase = idx_ut = None
                                 R = new_run()
-                                _ll = reader.rptr(lm + LogManager.LOG_LIST)
-                                last_size = (reader.ri32(_ll + List.SIZE) or 0) if _ll else 0
+                                # Re-seed the boundary cursor to the NEW lm's current tail (the old
+                                # ga_base/instance is dead after re-attach): skip the backlog so the
+                                # interrupted run's history isn't replayed as clears.
+                                _rs_read, _rs_size = _loglist_size_reader()
+                                log_cursor.seed(_rs_read, _rs_size, LOG_SCAN_CAP)
                                 last_alive = 0
                                 prev_dead = None
                                 cur_key = reader.ri32(csd + CommonSaveData.CURRENT_STAGE_KEY) if csd else None
@@ -1317,66 +1420,63 @@ def run(hz, output_dir, debug=False):
             if dead_now is not None:
                 prev_dead = dead_now
 
-            # close by LOG: StageClearLog (success) or StageFailedLog (fail)
+            # close by LOG: StageClearLog (success) or StageFailedLog (fail). Detection of which
+            # entries are NEW is rotation-aware (LogScanCursor, by OBJECT POINTER): the LOG_LIST is
+            # capped at 2000 and evicts from the HEAD once full, so the absolute index desyncs and an
+            # absolute-index cursor stops firing at saturation — every clear then missed (runs only
+            # 'abandoned', clear=0; one run accrues several stages). LABELING below is unchanged: each
+            # NEW entry by KLASS-POINTER (never an ELogType field) — see docs/invariants/log-event-detection.
             closed = False
-            loglist = reader.rptr(lm + LogManager.LOG_LIST)
-            size = reader.ri32(loglist + List.SIZE) if loglist else None
-            if size is not None and size != last_size:
-                if size > last_size:
-                    items = reader.rptr(loglist + List.ITEMS)
-                    for i in range(last_size, min(size, last_size + 300)):
-                        e = reader.rptr(items + Array.DATA + i * 8) if items else None
-                        if not e:
-                            continue
-                        kl = reader.rptr(e)
-                        if kl == sc_class:
-                            close_run("success", cur_key, e); closed = True
-                        elif kl == sf_class:
-                            close_run("fail", cur_key, e); closed = True
-                        elif gb_class and kl == gb_class:
-                            # GetBoxLog @0x40 is the TYPE ("TreasureChest_<Type>"), NOT an item key
-                            # (confirmed live). The authoritative tier is monster_type @0x50; the
-                            # exact box variant isn't in the event → map the tier -> the canonical
-                            # box key (BOX_KEY_BY_TIER). The old int(bk_str) swallowed EVERY drop.
-                            # ROUTING: a BOSS chest (mt 1/2) arrives ~0.6s AFTER the clear (even
-                            # in the SAME batch of entries: the close above already swapped R) → belongs
-                            # to the PENDING success, not the new run. Mob (mt=0) → current run. With no
-                            # pending (attached right after a clear) → current run + WARN; a real
-                            # chest is never discarded. See docs/invariants/run-lifecycle.
-                            mt = reader.ri32(e + GetBoxLog.MONSTER_TYPE)
-                            box_key = BOX_KEY_BY_TIER.get(mt)
-                            if box_key is not None:
-                                drop = {"box_key": box_key, "monster_type": mt}
-                                if (_box_belongs_to_pending(mt, pending is not None)
-                                        and _absorb_drop(pending["rec"], drop)):
-                                    pending["absorbed"].append(drop)
-                                    print(f"\n[box] boss box (mt={mt}) absorbed into closed "
-                                          f"run {pending['rec'].get('id')}")
-                                else:
-                                    if mt in TRAILING_BOX_TIERS:
-                                        # Two DISTINCT reasons in the log (the meter.log triage
-                                        # can't lie): no pending (e.g. attached right after
-                                        # a clear) vs absorb refused (pending rec out of
-                                        # shape — unreachable by construction today).
-                                        why = ("absorb refused (malformed pending rec)"
-                                               if pending is not None else "no pending close")
-                                        print(f"\n[box] WARN boss box (mt={mt}) — {why}; "
-                                              "credited to current run")
-                                    R["drops"].append(drop)
-                        elif die_class and kl == die_class:
-                            # HeroDie: @0x48 = the dead hero, @0x40 = the monster that killed (LIVE-CRACKED).
-                            victim = _suffix_int(reader.read_string(reader.rptr(e + HeroDieLog.VICTIM_HERO)))
-                            killer = _suffix_int(reader.read_string(reader.rptr(e + HeroDieLog.KILLER_MONSTER)))
-                            if victim is not None:
-                                R["deaths"][victim] = R["deaths"].get(victim, 0) + 1
-                                if killer is not None:
-                                    R["killers"].setdefault(victim, []).append(killer)
-                        elif res_class and kl == res_class:
-                            # Resurrection: @0x40 = the revived hero. Auto-revive (~115s) or the Priest's skill.
-                            rev = _suffix_int(reader.read_string(reader.rptr(e + ResurrectionLog.HERO)))
-                            if rev is not None:
-                                R["revives"][rev] = R["revives"].get(rev, 0) + 1
-                last_size = size
+            _scan_read, _scan_size = _loglist_size_reader()
+            for e in log_cursor.new_entries(_scan_read, _scan_size, LOG_SCAN_CAP):
+                kl = reader.rptr(e)
+                if kl == sc_class:
+                    close_run("success", cur_key, e); closed = True
+                elif kl == sf_class:
+                    close_run("fail", cur_key, e); closed = True
+                elif gb_class and kl == gb_class:
+                    # GetBoxLog @0x40 is the TYPE ("TreasureChest_<Type>"), NOT an item key
+                    # (confirmed live). The authoritative tier is monster_type @0x50; the
+                    # exact box variant isn't in the event → map the tier -> the canonical
+                    # box key (BOX_KEY_BY_TIER). The old int(bk_str) swallowed EVERY drop.
+                    # ROUTING: a BOSS chest (mt 1/2) arrives ~0.6s AFTER the clear (even
+                    # in the SAME batch of entries: the close above already swapped R) → belongs
+                    # to the PENDING success, not the new run. Mob (mt=0) → current run. With no
+                    # pending (attached right after a clear) → current run + WARN; a real
+                    # chest is never discarded. See docs/invariants/run-lifecycle.
+                    mt = reader.ri32(e + GetBoxLog.MONSTER_TYPE)
+                    box_key = BOX_KEY_BY_TIER.get(mt)
+                    if box_key is not None:
+                        drop = {"box_key": box_key, "monster_type": mt}
+                        if (_box_belongs_to_pending(mt, pending is not None)
+                                and _absorb_drop(pending["rec"], drop)):
+                            pending["absorbed"].append(drop)
+                            print(f"\n[box] boss box (mt={mt}) absorbed into closed "
+                                  f"run {pending['rec'].get('id')}")
+                        else:
+                            if mt in TRAILING_BOX_TIERS:
+                                # Two DISTINCT reasons in the log (the meter.log triage
+                                # can't lie): no pending (e.g. attached right after
+                                # a clear) vs absorb refused (pending rec out of
+                                # shape — unreachable by construction today).
+                                why = ("absorb refused (malformed pending rec)"
+                                       if pending is not None else "no pending close")
+                                print(f"\n[box] WARN boss box (mt={mt}) — {why}; "
+                                      "credited to current run")
+                            R["drops"].append(drop)
+                elif die_class and kl == die_class:
+                    # HeroDie: @0x48 = the dead hero, @0x40 = the monster that killed (LIVE-CRACKED).
+                    victim = _suffix_int(reader.read_string(reader.rptr(e + HeroDieLog.VICTIM_HERO)))
+                    killer = _suffix_int(reader.read_string(reader.rptr(e + HeroDieLog.KILLER_MONSTER)))
+                    if victim is not None:
+                        R["deaths"][victim] = R["deaths"].get(victim, 0) + 1
+                        if killer is not None:
+                            R["killers"].setdefault(victim, []).append(killer)
+                elif res_class and kl == res_class:
+                    # Resurrection: @0x40 = the revived hero. Auto-revive (~115s) or the Priest's skill.
+                    rev = _suffix_int(reader.read_string(reader.rptr(e + ResurrectionLog.HERO)))
+                    if rev is not None:
+                        R["revives"][rev] = R["revives"].get(rev, 0) + 1
 
             # Pending-close expired (GRACE elapsed with no more boss box) → flush and clear. AFTER
             # the LOG_LIST scan on purpose: a boss box surfacing on the SAME tick the

--- a/reader/tests/test_log_scan.py
+++ b/reader/tests/test_log_scan.py
@@ -1,0 +1,188 @@
+"""LogScanCursor — rotation-aware detection of NEW LogManager.LOG_LIST entries.
+
+The run-close boundary (StageClearLog/StageFailedLog + GetBox/HeroDie/Resurrection) is
+detected by scanning the LOG_LIST's NEW entries each tick. The list is CAPPED at 2000
+(metrics/events.py documents the cap); once full the game evicts from the HEAD to stay at
+the cap, so ABSOLUTE indices shift DOWN. The pre-fix loop used an absolute-index cursor
+(`[last_size, size)`, fired only on `size > last_size`): after the cap saturated, `size`
+stopped growing, the scan never ran again, and EVERY subsequent StageClearLog was missed —
+runs only closed via the "abandoned" path (clear_time=0) and one open run accumulated several
+stages (live mobs 1703/652). A reader/game restart did NOT fix it (the game process keeps the
+saturated list; the cursor just re-seeds to the cap).
+
+These tests pin the rotation-aware contract: identity is the entry's OBJECT POINTER (the list
+slot's value — each LogData is a managed object), never its index, so head-eviction can't
+desync detection. Guards docs/invariants/run-lifecycle + docs/invariants/log-event-detection."""
+
+from meter_windows import LogScanCursor
+
+
+def _fake_list(ptrs):
+    """A read_ptr_at(i) over a Python list of entry pointers (oldest->newest), mirroring
+    reader.rptr(items + Array.DATA + i*8). Out-of-range / None slot -> None (a bad read)."""
+    def read_ptr_at(i):
+        return ptrs[i] if 0 <= i < len(ptrs) and ptrs[i] else None
+    return read_ptr_at
+
+
+CAP = 300   # per-tick scan cap (same magnitude as the pre-fix min(size, last_size+300))
+
+
+class TestSeedSkipsBacklog:
+    """On attach / re-resolve the cursor SEEDs to the current tail WITHOUT replaying the
+    pre-existing backlog as 'new' — the exact semantic of the old `last_size = current size`.
+    Otherwise the whole history of a long session would be re-processed as clears on attach."""
+
+    def test_seed_yields_nothing_and_marks_tail_seen(self):
+        ptrs = [100, 200, 300]
+        c = LogScanCursor()
+        c.seed(_fake_list(ptrs), len(ptrs), CAP)
+        # nothing new right after seeding the same list
+        assert c.new_entries(_fake_list(ptrs), len(ptrs), CAP) == []
+
+    def test_unseeded_first_call_self_seeds_no_replay(self):
+        # defensive: new_entries before an explicit seed must NOT replay the backlog.
+        ptrs = [100, 200, 300]
+        c = LogScanCursor()
+        assert c.new_entries(_fake_list(ptrs), len(ptrs), CAP) == []
+
+
+class TestAppendOnlyGrowth:
+    """Regression: the normal case (list below the cap, only grows at the tail) keeps working —
+    each new entry is returned exactly once, in order."""
+
+    def test_single_new_entry(self):
+        c = LogScanCursor()
+        c.seed(_fake_list([10, 20]), 2, CAP)
+        assert c.new_entries(_fake_list([10, 20, 30]), 3, CAP) == [30]
+
+    def test_multiple_new_entries_in_order(self):
+        c = LogScanCursor()
+        c.seed(_fake_list([10, 20]), 2, CAP)
+        assert c.new_entries(_fake_list([10, 20, 30, 40, 50]), 5, CAP) == [30, 40, 50]
+
+    def test_no_growth_yields_nothing(self):
+        c = LogScanCursor()
+        c.seed(_fake_list([10, 20]), 2, CAP)
+        same = _fake_list([10, 20])
+        assert c.new_entries(same, 2, CAP) == []
+        assert c.new_entries(same, 2, CAP) == []
+
+    def test_each_entry_returned_only_once_across_ticks(self):
+        c = LogScanCursor()
+        c.seed(_fake_list([1]), 1, CAP)
+        assert c.new_entries(_fake_list([1, 2]), 2, CAP) == [2]
+        assert c.new_entries(_fake_list([1, 2, 3]), 3, CAP) == [3]
+        assert c.new_entries(_fake_list([1, 2, 3]), 3, CAP) == []
+
+
+class TestCapRotation:
+    """THE BUG. The list is pinned at the cap and rotates (evict head, append at tail) so size
+    NEVER changes. The pre-fix absolute-index scan fired only on `size > last_size` and so missed
+    EVERY post-cap entry. Pointer identity detects the tail append regardless of size/index."""
+
+    def test_rotation_with_size_pinned_detects_new_tail_entry(self):
+        cap_len = 2000
+        before = list(range(1, cap_len + 1))          # pointers 1..2000, size == cap
+        c = LogScanCursor()
+        c.seed(_fake_list(before), cap_len, CAP)
+        # rotate: evict the head (1), append a NEW entry (9999) at the tail; size STILL 2000.
+        after = before[1:] + [9999]
+        assert len(after) == cap_len                   # size unchanged — the pre-fix killer
+        assert c.new_entries(_fake_list(after), cap_len, CAP) == [9999]
+
+    def test_repeated_rotation_each_new_tail_detected_once(self):
+        cap_len = 2000
+        lst = list(range(1, cap_len + 1))
+        c = LogScanCursor()
+        c.seed(_fake_list(lst), cap_len, CAP)
+        seen_new = []
+        for newp in (9001, 9002, 9003):
+            lst = lst[1:] + [newp]                      # one eviction + one append per tick
+            seen_new += c.new_entries(_fake_list(lst), cap_len, CAP)
+        assert seen_new == [9001, 9002, 9003]
+
+    def test_multiple_appends_during_one_rotated_tick(self):
+        # the reader stalled a tick: several entries appended (with head eviction) since last scan.
+        cap_len = 2000
+        lst = list(range(1, cap_len + 1))
+        c = LogScanCursor()
+        c.seed(_fake_list(lst), cap_len, CAP)
+        lst = lst[3:] + [7001, 7002, 7003]              # 3 evicted, 3 appended; size pinned
+        assert c.new_entries(_fake_list(lst), cap_len, CAP) == [7001, 7002, 7003]
+
+
+class TestClearThenBoxOrderingAcrossRotation:
+    """The pending-close (run-lifecycle) depends on detection ORDER: the StageClearLog must surface
+    BEFORE its trailing boss GetBoxLog so close_run opens the pending and the box is then absorbed
+    into it (not credited to the next run). The boss box trails the clear ~0.6s — it can land a tick
+    later (separate growth) OR in the same batch. The cursor yields oldest->newest, so the close
+    always precedes the box. This pins that property under cap-rotation (where the bug lived)."""
+
+    CLEAR, BOX = 0xC1EA, 0xB0C5    # sentinel pointers standing in for StageClearLog / GetBoxLog
+
+    def test_clear_then_box_separate_rotated_ticks(self):
+        cap_len = 2000
+        lst = list(range(1, cap_len + 1))
+        c = LogScanCursor()
+        c.seed(_fake_list(lst), cap_len, CAP)
+        # tick N: clear appended at the tail (head evicted), size pinned -> close opens the pending.
+        lst = lst[1:] + [self.CLEAR]
+        assert c.new_entries(_fake_list(lst), cap_len, CAP) == [self.CLEAR]
+        # tick N+1: the boss box appends ~0.6s later (another rotation) -> absorbed into the pending.
+        lst = lst[1:] + [self.BOX]
+        assert c.new_entries(_fake_list(lst), cap_len, CAP) == [self.BOX]
+
+    def test_clear_then_box_same_rotated_batch_in_order(self):
+        # both surface on the SAME tick (one stalled scan): order must still be clear-then-box, so
+        # the close swaps R first and the box routes to the freshly-opened pending.
+        cap_len = 2000
+        lst = list(range(1, cap_len + 1))
+        c = LogScanCursor()
+        c.seed(_fake_list(lst), cap_len, CAP)
+        lst = lst[2:] + [self.CLEAR, self.BOX]
+        assert c.new_entries(_fake_list(lst), cap_len, CAP) == [self.CLEAR, self.BOX]
+
+
+class TestScanCapBounded:
+    """The per-tick scan is bounded (the pre-fix loop capped at 300). A pathological burst beyond
+    the cap stops at the cap (same accepted exposure as before) and never scans the whole list."""
+
+    def test_scan_does_not_exceed_cap_reads(self):
+        cap_len = 2000
+        before = list(range(1, cap_len + 1))
+        c = LogScanCursor()
+        c.seed(_fake_list(before), cap_len, CAP)
+        reads = {"n": 0}
+
+        def counting(i):
+            reads["n"] += 1
+            return before[i] if 0 <= i < len(before) and before[i] else None
+
+        # last-seen pointer evicted far beyond the window -> can't early-stop; still bounded by CAP.
+        rotated = list(range(10_001, 10_001 + cap_len))   # an ENTIRELY fresh list (full rotation)
+
+        def counting_rot(i):
+            reads["n"] += 1
+            return rotated[i] if 0 <= i < len(rotated) and rotated[i] else None
+
+        c.new_entries(counting_rot, cap_len, CAP)
+        assert reads["n"] <= CAP + 1     # never walked all 2000 slots
+
+
+class TestExceptionSafety:
+    """Per-entry exception-safety contract: falsy slots (None/0 from a bad read) are skipped, not
+    collected and not crashing — the loop primitives (rptr) return None on unreadable memory."""
+
+    def test_none_slots_are_skipped(self):
+        c = LogScanCursor()
+        c.seed(_fake_list([10]), 1, CAP)
+        # a hole (None) between real entries: skipped, the real new ones still returned.
+        ptrs = [10, None, 20, 0, 30]
+        assert c.new_entries(_fake_list(ptrs), 5, CAP) == [20, 30]
+
+    def test_size_zero_or_none_yields_nothing(self):
+        c = LogScanCursor()
+        c.seed(_fake_list([10, 20]), 2, CAP)
+        assert c.new_entries(_fake_list([]), 0, CAP) == []
+        assert c.new_entries(_fake_list([]), None, CAP) == []


### PR DESCRIPTION
> ⚠️ **DRAFT — do not merge until the Windows live-validation gate passes** (see Verification).

## The bug (player-confirmed, 2026-06-26)
After a long *single* game session, runs silently stopped counting: every run closed as `abandoned` with **`clear_time=0`**, the live mob count ran **past the stage total** (e.g. `1703/652` — several stages merged into one open run), and "no new runs" appeared. The operator hadn't changed anything in-game.

## Root cause
The reader detects stage end by scanning `LogManager.LOG_LIST` for `StageClearLog`, using an **absolute-index cursor** (`[last_size, size)`, fired only when `size` grows). The game's list is **capped at 2000** and **evicts from the HEAD** once full → absolute indices shift down every append → the cursor desyncs **permanently**: `size` stops growing, the scan never runs, every clear is missed. Because it's the **game process's** list state, a reader/app restart doesn't fix it (the cursor just re-seeds to the saturated tail) — only restarting the **game** does (fresh empty list). Log fingerprint: same game PID across reader restarts + a `[box] WARN boss box — no pending close` at the exact break.

## Fix
Replace the absolute-index cursor with **`LogScanCursor`**, which tracks the last-processed entry by its **object pointer** (stable across head-eviction): each tick it scans the tail backward, stops at the first already-seen pointer, and yields new entries **oldest→newest** (so a clear is still processed before its trailing boss box → pending-close/box-absorption unchanged). Labeling stays klass-pointer based. Purely a change to *which entries are new* — schema, predicates, and the abandoned path are untouched.

## Verification
- **Offline (proves the LOGIC):** `ruff` ✅ + `pytest` **525 passed** ✅ — incl. the new `tests/test_log_scan.py` **red→green reproduction** of the cap-rotation bug (with the old absolute-index semantics the post-cap clear is missed; with the cursor it's caught) + the docs drift-test. Re-run locally, not just the agent's claim.
- ⛔ **PENDING (required before merge): the Windows live-validation gate.** The reader is win32-only; the offline MockReader proves the cursor logic, **not** the live game's head-eviction behavior. Need: `reader/scripts/validate_live.py` PASS (esp. `run-cycle`) on the real game, then ideally a long farm crossing the 2000-entry cap to confirm clears keep registering with `clear_time≠0`. A fixed reader + a `logscan_probe.py` (runs the real cursor vs the old logic against the live list) are staged on the `tbh-meter-dev` share for exactly this.

## Notes
- **CI:** reader-only PR — the app/CodeQL required checks are path-filtered and may not report, so this can show "blocked" and need an owner bypass-merge (the known path-filter trap).
- Shares `reader/meter_windows.py` + `reader/docs/invariants/run-lifecycle.md` with #83 (partial-95) in **different regions**; whichever merges second just needs an "Update branch" (merge `main` — no rebase/force).
