### PR TITLE
fix(reader): force UTF-8 on validate_live stdout so the Windows gate doesn't crash

### DIFF
--- a/reader/scripts/validate_live.py
+++ b/reader/scripts/validate_live.py
@@ -37,6 +37,15 @@ import os
 import sys
 import time
 
+# Force UTF-8 on stdout/stderr so a diagnostic glyph (e.g. "↳") never crashes print() on a Windows
+# console/redirect that defaults to cp1252 — without this the gate dies with UnicodeEncodeError before
+# it can print the PASS/FAIL summary. The file tee (validate_live_out.txt) is already UTF-8.
+try:
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+except (AttributeError, ValueError):
+    pass
+
 # bootstrap identical to seed_calib_capture.py: finds reader/ from the share root or from reader/scripts/.
 _here = os.path.dirname(os.path.abspath(__file__))
 _reader_root = next(


### PR DESCRIPTION
## What

`scripts/validate_live.py` prints diagnostic lines containing `↳` (U+21B3). On Windows, Python's stdout falls back to **cp1252** on a non-UTF-8 console or when output is **redirected to a file**, so `print()` raises `UnicodeEncodeError: 'charmap' codec can't encode character '\u21b3'` and the gate **dies before printing the PASS/FAIL summary** — even though every metric resolved fine.

## Why now

Hit live while running the post-merge validation for #85: the reader attached, calibrated, and was about to report every check, but the script crashed on the first `[diag sm]` line under a redirected stdout.

## Fix

`sys.stdout/stderr.reconfigure(encoding="utf-8")` at startup (guarded for older interpreters). The file tee (`validate_live_out.txt`) was already UTF-8 — this just makes the console/redirect path match so the gate runs to completion anywhere.

Tooling-only; **no reader/runtime behavior change**. `ruff` + `py_compile` clean locally.

> Note: `logscan_probe.py` has the same pattern but lives only on the dev share (not versioned in the repo).