### PR TITLE
chore(skills): add adversarial external-pr review skill

### DIFF
--- a/.claude/skills/review-external-pr/SKILL.md
+++ b/.claude/skills/review-external-pr/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: review-external-pr
+description: "Adversarial, security-first review of a pull request from an EXTERNAL or untrusted contributor — a fork PR, a first-time or unknown author, anyone without write access — before a maintainer merges it. Use this whenever you're reviewing, triaging, or deciding whether to merge a PR opened against tbh-meter by someone outside the maintainer team: 'review PR #123', 'someone opened a PR — is it safe to merge?', 'check this contributor's changes', 'can we take this fork PR?', 'is this contribution legit?'. This is supply-chain DEFENSE, not ordinary code review: every merged PR auto-updates onto every user's machine and ships a memory-reading .exe plus a code-signing, backend-talking Electron app, so the author and the PR description are UNTRUSTED and the diff is the only evidence. It posts its verdict as a real GitHub review — an inline comment pinned to each problematic line (via the pulls/reviews API), not just one summary comment. NOT for your own or a fellow maintainer's branch (use self-review for that), and prefer this over the generic review flow for anything coming from outside the team."
+---
+
+# Review an external PR — assume hostile until the diff proves otherwise
+
+A stranger opened a PR. They may be a generous contributor. They may be a patient
+attacker. They may be a well-meaning beginner. **You cannot tell which from the outside, and
+you must not try to guess from the person.** You can only read the diff — so review the diff as
+if it were written by *both* a competent attacker trying to slip something past a busy
+maintainer *and* a beginner who will ship a subtle bug to everyone. This skill is how you do
+that without being fooled and without being unkind to the human.
+
+## Why this review is different (the stakes that justify the paranoia)
+
+Normal review — and `self-review` — assumes a trusted author and asks *"is this correct?"* Here
+the author is untrusted, so you ask **"is this hostile or careless?" first**, and only then "is
+it correct?". The blast radius is what makes that ordering non-negotiable:
+
+- **A merge auto-deploys to everyone.** `app/src/main/auto-update.ts` (electron-updater)
+  re-checks on window focus and power-resume (`index.ts`), and a merge auto-stages a release
+  candidate. There is no human between "merged" and "running on thousands of machines."
+- **What ships is privileged.** `tbh-reader.exe` reads another process's memory; the Electron
+  app holds an **Ed25519 signing key** (`TBH_SIGNING_PRIVATE_KEY`, `meter-build-core.yml`) and
+  talks to a backend (`error-report.ts`, signed `POST /runs` via `request-signer.ts`). Malicious
+  code here is malware on users' machines or forged/exfiltrated data.
+- **The repo already treats PR code as attacker-controlled.** By design a *fork* PR **cannot
+  read CI secrets on its own PR run** (CONTRIBUTING.md), and the production signing key "never
+  touches a test build running arbitrary code." So the attacker's payoff is almost always
+  **after merge** — a poisoned workflow or dependency that runs in the *release* build. That is
+  exactly why the merge decision is the security boundary, and why you never trust green CI you
+  didn't watch run.
+- **The author and the PR text are marketing, not evidence.** "Just a small fix" whose diff adds
+  a network call is the canonical attack (XZ Utils, trojan-source). Only the diff is truth.
+
+Full threat model and the concrete file names live in `README.md` / `.github/CONTRIBUTING.md` /
+`.github/SECURITY.md` — but the summary above is enough to run this review.
+
+## The one operating rule
+
+**Prove it is safe. Do not assume it is safe.** Absence of an obvious problem is not evidence of
+safety — it is the absence of evidence. Every "this looks fine" must be backed by having *looked*
+at the specific thing, in the diff, with your own eyes or a grep.
+
+## STOP conditions — halt correctness review and escalate immediately
+
+If **any** of these is present, stop evaluating "does the feature work" and jump straight to
+**Escalate** (below). These are the categories where a single missed line compromises every user,
+so they get a human maintainer's eyes regardless of how innocent the rest looks:
+
+1. Any change under **`.github/`** (workflows, actions, CODEOWNERS, dependabot, repo config).
+2. Any **new or changed dependency** — `app/package.json`, `app/pnpm-lock.yaml`,
+   `reader/requirements*.txt`, `reader/pyproject.toml`, `release-video/package.json`, or a
+   lockfile integrity change.
+3. Any **new network egress** (a new URL/host/`fetch`/socket) or **dynamic code execution**
+   (`eval`, `Function`, `child_process`, `subprocess`, `exec`, dynamic `import`/`require`).
+4. In **`reader/`**: any memory *write*/inject primitive, any network, any subprocess, or any
+   third-party import (the reader is zero-dependency and read-only by law).
+5. A **hand-edit to a generated/synced file** (`app/src/shared/data/`,
+   `app/src/renderer/public/{sprites,heroes}/`).
+6. **Obfuscated / encoded content** — minified blobs, long base64/hex, or non-ASCII inside code
+   (trojan-source).
+7. The diff's **scope wildly exceeds** what the PR title/description claims.
+
+Escalating is not the same as rejecting — it means a human maintainer must make the call with the
+finding in front of them. Say so plainly and hand them the evidence.
+
+## The pipeline
+
+Run these in order. The security sweep gates everything after it — a PR that trips a STOP
+condition doesn't earn a correctness review until the maintainer has weighed the risk.
+
+### 0 — Intake: pull the PR and establish that it's external
+
+```bash
+gh pr view <N> --json number,title,body,author,isCrossRepository,headRepositoryOwner,\
+headRefName,baseRefName,additions,deletions,changedFiles,files,mergeable,mergeStateStatus,\
+labels,statusCheckRollup
+# author_association (OWNER/MEMBER/COLLABORATOR/CONTRIBUTOR/FIRST_TIME_CONTRIBUTOR/NONE) is a REST
+# field — `gh pr view --json` doesn't expose it, so read it from the API:
+BASE=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+gh api "repos/$BASE/pulls/<N>" --jq '.author_association'
+gh pr diff <N> > /tmp/pr-<N>.diff        # the diff is your primary artifact — grep THIS, not the tree
+```
+
+- **Is it actually external?** `isCrossRepository: true` (a fork) and/or
+  `author_association` of `FIRST_TIME_CONTRIBUTOR` / `NONE` / `CONTRIBUTOR` (not `OWNER` /
+  `MEMBER` / `COLLABORATOR`) means treat as untrusted. Maintainers are @marioalvial,
+  @viniarruda, @pedrobullo (confirm against `.github/CODEOWNERS`). If it's a maintainer's own
+  branch, this is the wrong skill — use `self-review`.
+- **Map the touched areas** from `files`: reader / app-main / app-renderer / data / workflows /
+  deps / docs. This decides which parts of `references/area-review.md` you read.
+
+### 1 — Provenance & honesty
+
+You are not judging the person — you are checking whether the PR *presents itself honestly*, because
+dishonest framing is the wrapper every payload comes in.
+
+- Does the **diff match the description**? A "typo fix" or "docs" PR that touches code, config,
+  workflows, or deps is a contradiction — investigate the contradiction, not the description.
+- Is the change **focused**? Unrelated changes bundled into one PR are the #1 hiding place for a
+  payload. Each unrelated hunk is a separate thing to justify.
+- Watch for social engineering: manufactured urgency, "trivial, please merge fast," flattery, or
+  a first PR that reaches straight into `reader/`, `auto-update.ts`, `request-signer.ts`, or
+  `.github/`.
+
+### 2 — Adversarial red-flag sweep  ← the heart of this skill
+
+**Read `references/red-flags.md` now and run its greps against `/tmp/pr-<N>.diff`.** It is the
+exhaustive, grep-able catalog of hostile patterns — CI/workflow tampering, dependency/supply-chain
+tricks, network/exfiltration, code-exec, obfuscation/trojan-source, generated-data poisoning,
+secrets, and scope abuse — each with the command to find it and the reason it matters. Every STOP
+condition above has its detection there.
+
+### 3 — CI reality check (never trust green you didn't watch run)
+
+- **On a fork PR, held/absent checks are NORMAL, not passing.** Workflows require maintainer
+  approval before they run, so "no checks reported" or a pending state means *nothing ran* — it is
+  not a pass. Never accept the contributor's "tests pass on my machine" as evidence either.
+- **`.github/`-only or docs-only PRs can sit BLOCKED forever** because the required app/reader/
+  CodeQL checks are path-filtered and never report on a diff that doesn't touch their paths. That's
+  the known path-filter trap, not a failure — the owner bypass-merges after review. Don't mistake it
+  for a broken PR.
+- **Before you approve a workflow run**, do the §2 sweep — approving a run *is* the moment a fork
+  first gets to execute. After the sweep, either approve the run and read the results, or run the
+  gates yourself (§5).
+
+### 4 — Area-specific correctness & invariants
+
+Only now, once the security posture is understood, review whether the change is actually correct.
+**Read the matching section(s) of `references/area-review.md`** for each area the PR touches — it
+carries the per-area checklists grounded in this repo's real invariants (the reader's read-only /
+obscured-data / offset-single-source laws and its `docs/reference/anti-patterns.md` sweep, the app
+main-process privilege boundary, the renderer XSS + i18n-every-key guard, the generated-data rules,
+Conventional-Commit requirements).
+
+### 5 — Verify locally, in isolation
+
+Untrusted code is dangerous to *run*, not just to merge — so isolate before executing anything.
+
+- **Review dependencies and lifecycle scripts BEFORE installing.** `pnpm install` runs
+  `postinstall` hooks; a malicious one executes on *your* machine. Read `references/red-flags.md` §B
+  first. Prefer a throwaway worktree/checkout and, for anything you're unsure of, a VM/sandbox.
+
+  ```bash
+  gh pr checkout <N>            # in a scratch worktree, not your main tree
+  ```
+
+- Run the same gates CI runs, and watch them pass yourself:
+
+  ```bash
+  cd app    && pnpm install --frozen-lockfile && pnpm sync-data && pnpm check && pnpm test
+  cd reader && pip install ruff -r requirements-dev.txt && ruff check . && python -m pytest
+  ```
+
+- For **reader** changes: `python -m pytest tests/` also runs the docs drift-test; a live-behavior
+  change can only be truly validated on Windows against the running game (`validate_live.py`) — if
+  the PR could affect live capture, say so and route it to Mario for the Windows gate. For
+  **overlay/list UI** changes, verify on real pixels (seeded `~/tbh-meter/` run), not just unit tests.
+
+### 6 — Compose the verdict, then post it as a real GitHub review
+
+The deliverable is a **formal GitHub review** — a summary plus an **inline comment pinned to each
+problematic line**, submitted as one review carrying a single verdict — not a lone PR comment.
+Distrust the diff, respect the human: every comment names the concrete failure/attack scenario and
+the fix, so the contributor can act and a maintainer can verify, and none of it reads as an
+accusation.
+
+**Anchor each finding to a real diff line.** GitHub only accepts an inline comment on a line that is
+part of the PR's diff. Added and context lines anchor on `side: RIGHT` using the **new-file** line
+number; removed lines anchor on `side: LEFT` using the **old-file** number; a multi-line span adds
+`start_line` + `start_side`. Read the numbers off each hunk header (`@@ -old,n +new,m @@`, then count
+down the `+`/context lines). A finding about code that is *not* in the diff (e.g. "the 15 locale
+files you didn't touch") can't be an inline comment — put it in the summary body, or pin it to the
+nearest related added line and say so there.
+
+**Map the decision to a review event:**
+- BLOCK / REQUEST CHANGES → `REQUEST_CHANGES`
+- APPROVE (with nits) → `APPROVE` (nits ride along as inline comments)
+- ESCALATE → `COMMENT` — never let the skill formally approve or reject something whose call belongs
+  to a human maintainer; post the findings and hand off the decision.
+
+Build the payload as JSON and submit it in one call. The review posts to the **base** repo (this
+one) even for a fork PR, and one request carries the summary + every inline comment together:
+
+```bash
+BASE=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+gh api --method POST "/repos/$BASE/pulls/<N>/reviews" --input /tmp/review-<N>.json
+```
+
+```jsonc
+// /tmp/review-<N>.json — one review, N inline comments
+{
+  "event": "REQUEST_CHANGES",
+  "body": "<the summary-body template below, as Markdown>",
+  "comments": [
+    { "path": "app/src/main/auto-update.ts", "line": 88, "side": "RIGHT",
+      "body": "🚨 **HIGH — update feed repointed.** This sends every user's updater to <host>. <fix>" },
+    { "path": "reader/game/save.py", "start_line": 40, "start_side": "RIGHT", "line": 44, "side": "RIGHT",
+      "body": "Reads an Obscured offset (see obscured-data-offlimits) → returns XOR garbage. <fix>" }
+  ]
+}
+```
+
+If the API returns **422**, one comment's `line`/`side` isn't in the diff — move that finding to the
+body and re-post. You can rehearse safely with `"event": "COMMENT"` (same inline comments, no verdict),
+and omit `event` only if you deliberately want a PENDING draft.
+
+**Post publicly only with the maintainer's go-ahead.** A `REQUEST_CHANGES` review notifies a real
+person and is on the public record, so show the maintainer the fully composed review first (summary +
+every inline comment, each with its `path:line`) and post on their OK — they can say "just post it" to
+skip the preview thereafter. Regardless: **never `APPROVE` blindly and never merge** — this skill
+recommends; the human decides to merge.
+
+## Summary-body template (the review `body`)
+
+```
+## External-PR review — #<N> "<title>"
+Decision:  BLOCK · REQUEST CHANGES · APPROVE (with nits) · ESCALATE TO MAINTAINER
+Author:    <maintainer | known contributor | first-time | unknown>  ·  <fork? yes/no>
+Areas:     reader · app-main · app-renderer · data · workflows · deps · docs
+Gates:     <watched green | HELD (fork, not run) | I ran locally → result>
+STOP hit:  <none | which condition(s)>
+
+**Summary.** <2–4 sentences for the contributor: what the PR does, the headline risk, the decision —
+plain and respectful.>
+
+**Findings that don't map to a changed line** (the inline comments below cover the rest):
+- 🚨 [CRITICAL|HIGH|MED] <file> — <what> — <attack/failure scenario> — <evidence>
+- <invariant/correctness finding with no diff line to pin to>
+
+### Escalation (for the maintainer)
+<any change to workflows/.github, signing, dependencies, reader memory-safety, or the upload/exfil
+surface — even if it looks clean; state exactly what a human must double-check before merge.>
+```
+
+**Each inline comment** (`comments[].body`) follows the same shape, scoped to *that* line:
+`<severity or type> — <the problem on THIS line> — <why it's wrong / the attack or failure> — <the fix>`.
+Security findings lead with 🚨 and a severity; correctness findings name the invariant; nits start "nit:".
+
+## Escalate — the human-maintainer bar
+
+Some categories are never "approved by a review skill," because the cost of being wrong is the whole
+user base: **any `.github/`/workflow change, any dependency/lockfile change, any signing/upload/
+auto-update change, and any reader memory-safety or network/subprocess change.** For these, your job
+is to surface the finding with maximum clarity and hand the decision to Mario or a code owner — not
+to bless it. When in doubt, escalate; a false alarm costs a minute, a missed payload ships to
+everyone.
+
+## References
+
+- `references/red-flags.md` — the adversarial attack-surface catalog (run its greps in §2 and §5).
+- `references/area-review.md` — per-area correctness checklists tied to the repo's real invariants (§4).

--- a/.claude/skills/review-external-pr/references/area-review.md
+++ b/.claude/skills/review-external-pr/references/area-review.md
@@ -1,0 +1,113 @@
+# Area review — correctness & invariants, per touched area
+
+Reach here only after the red-flag sweep (SKILL.md §2, `references/red-flags.md`) — this is the
+"is it correct?" pass. Read only the sections for the areas the PR actually touches (from the §0
+`files` list). Each check is tied to a real invariant in this repo; the point is to catch the changes
+that *silently corrupt data or break a shipped build*, which a stranger has no way to know about.
+
+---
+
+## `reader/` — the highest-risk area, and the one a newcomer is least equipped to touch safely
+
+The reader reads another process's memory and is frozen into `tbh-reader.exe`. Its rules are
+non-obvious and their violation ships bad data or malware to every user. **Before reviewing a reader
+diff, open `reader/docs/_index.md`** (the knowledge base, indexed by symptom) **and sweep the diff
+against `reader/docs/reference/anti-patterns.md`** — that file is the maintainers' own grep-able list
+of known smells, each linked to the invariant it violates. Then confirm:
+
+- **Read-only / memory-safety** (`invariants/memory-safety`, `shared/memory.py`): the reader opens the
+  process with `PROCESS_VM_READ` only, null-guards every dereference, caps iteration, and **never
+  writes or injects**. Any `WriteProcessMemory`, `CreateRemoteThread`, `VirtualAllocEx`, or `OpenProcess`
+  with write/operation access is a hard reject (also caught in red-flags §C). This is both a safety
+  invariant and the project's promise in SECURITY.md.
+- **Zero runtime dependencies**: pure `ctypes` + stdlib. A new import of a third-party package — or of a
+  network/subprocess stdlib module — doesn't belong here (red-flags §B/§C).
+- **Never read Obscured data** (`invariants/obscured-data-offlimits`): Obscured (XOR-masked) fields read
+  as garbage; core stats live behind `@CORE_STATS_OBSCURED`/`@CACHE_OBSCURED` and must not be read
+  directly. Hero class is `EEquipClassType`, **never** `EHeroType` (an orphan enum). A diff that reads
+  an Obscured offset or switches to `EHeroType` is wrong even if tests pass.
+- **Offsets live in one place** (`invariants/offsets-single-source`, `config/offsets.py`): every
+  offset/enum/stride belongs in `config/offsets.py`; a business rule belongs in its logic module. A
+  magic offset inlined into a metric or the orchestrator is a defect (and `orchestration-purity`:
+  `meter_windows.py` is a thin orchestrator with no inline reads).
+- **Dict strides** (`invariants/dict-strides`): `DictFloat` (0x10/@0xC) vs `Dict8B` (0x18/@0x10) — mixing
+  them corrupts silently. Any new dict walk must use the right stride for the structure.
+- **Name-free resolution** (`invariants/rva-index-resolution`, `gold-singleton-resolution`,
+  `log-event-detection`): obfuscated singletons resolve by *structure*, events by *klass-pointer* —
+  never by the (stripped/drifting) name or the `ELogType` field. A resolver that keys on a literal name
+  will break on the next game recompile.
+- **Metric fallback chains** (`invariants/metric-fallback-chains`): LIVE → SAVE → never wallet/total;
+  `run_gain` is `None` when non-monotonic; the source tag must preserve any degradation honestly.
+- **Run lifecycle** (`invariants/run-lifecycle`): start via `LOG_LIST`; end on
+  `StageClearLog`/`StageFailedLog`; the <30s and boss-box-post-clear rules. Party is LIVE
+  (`StageManager.HeroList`), never the roster (`invariants/party-live-resolution`).
+- **Schema & cache versioning** (`invariants/schema-versioning`, `cache-management`): adding a run field
+  that changes the record shape bumps `RAW_SCHEMA_VERSION` *and* is normalized app-side; a `CACHE_FMT`
+  change requires re-capturing `config/calib_seed.json` or it falls back to a cold scan.
+- **The combat law**: the party is *always* fighting; there is no "not in combat" state. A `validate_live.py`
+  FAIL is a real regression, never "wasn't in combat" — so a PR that "fixes" a failure by assuming an
+  idle state is misdiagnosing a real bug.
+- **Gates**: `ruff check .` and `python -m pytest` (the latter includes `test_docs_consistency.py`, the
+  docs↔code drift-test — a reader change that makes a note lie about the code reddens it). **Live
+  behavior can only be validated on Windows against the running game.** If the change could affect live
+  capture (offsets, resolution, lifecycle, metrics), route it to Mario for the `validate_live.py` gate —
+  Linux/mac tests passing is necessary, not sufficient.
+
+## `app/` main process (`src/main/`) — the privilege boundary
+
+Main-process code has Node/OS privileges the renderer must never get. State flows
+`reader-policy.ts` → `reader-process.ts` → `ipc.ts` → renderer via the `MeterApi` preload
+(contract in `src/shared/ipc-types.ts`).
+
+- **Window security**: in `BrowserWindow` `webPreferences`, `contextIsolation` stays **on**,
+  `nodeIntegration` **off**, `sandbox` not disabled, and the preload stays the only bridge. A diff that
+  flips any of these hands a compromised renderer full Node access.
+- **IPC surface**: a new `ipcMain.handle`/`ipcMain.on` handler must validate its arguments and must not
+  turn renderer-supplied input into filesystem/shell/exec/network actions. `shell.openExternal` with a
+  URL derived from untrusted data is a hole.
+- **The sensitive modules**: `auto-update.ts` (feed URL + signature verification — electron-updater is
+  CJS and bundled on purpose; disabled for the RC variant), `request-signer.ts` (Ed25519 signing of
+  `POST /runs`), `error-report.ts` + `share.ts` (what data is uploaded and where — `API_URL`). Changes
+  here are red-flags §C and escalate.
+- `error-report.ts` size caps mirror the API's `@tbh/shared meterErrorReportSchema` (an external package,
+  not vendored) — a change that desyncs the `MAX_*` constants breaks reports.
+- **Gates**: `pnpm check` (eslint + tsc over both tsconfigs) and `pnpm test` (vitest; `pretest` syncs data).
+
+## `app/` renderer (`src/renderer/`) — overlay / list / splash
+
+- **XSS**: untrusted run/leaderboard data rendered via `dangerouslySetInnerHTML`, or a URL/HTML string
+  built from server or run data, is an injection path. React escapes by default — a diff that opts out
+  needs a hard reason.
+- **The i18n every-key guard**: adding a UI string means the en-us key must be added to **all** locale
+  dicts or `pnpm test` (`i18n.test.ts`) goes red — runtime falls back to English but the *test* does not.
+  The convention is to translate en-us + pt-br and English-placeholder the rest; never machine-translate,
+  and the repo is English-only outside the locale dicts.
+- **IDs, not names** (`process/data-contract-id-based`): the reader emits IDs (`itemKey`/`statId`/
+  `heroKey`/…); the front end resolves display names via `data/*.json`. A renderer change that expects
+  names from the reader breaks the contract.
+- **Real-pixel verification**: overlay/list changes must be verified on a seeded `~/tbh-meter/` run and a
+  frame attached — unit tests don't prove the overlay looks right (app/CLAUDE.md).
+
+## `data/` and generated dirs
+
+- `app/src/shared/data/` and `app/src/renderer/public/{sprites,heroes}/` are **generated** — see
+  red-flags §E. Reject hand-edits; the source is the `data/` snapshot via `scripts/refresh-game-data.mjs`.
+- A `data/` change should look like a coherent datamine output, not arbitrary edits; verify sprite/asset
+  provenance rather than trusting the file.
+
+## `.github/` / workflows
+
+Any change here is red-flags §A → escalate. Correctness-wise, `actionlint` runs in CI; but the security
+review dominates — a workflow diff is judged on what it could do with secrets after merge, not on whether
+it's syntactically valid.
+
+## Docs / chore / other
+
+- **Conventional Commits are load-bearing**: the release version and changelog are computed from commit
+  subjects (`feat` → minor, `fix` → patch, breaking → major; `pr-title.yml` lints the PR title). A
+  mislabeled `feat` that's actually breaking, or a non-conventional subject, corrupts the release. Flag it.
+- **Docs-only / `.github`-only PRs** hit the path-filter trap (SKILL.md §3): required app/reader/CodeQL
+  checks never report on a diff that doesn't touch their paths, so the PR looks permanently "blocked."
+  That's expected — an owner bypass-merges after review; don't mistake it for a failing PR.
+- Even a docs PR gets the §2 sweep: a link to an attacker-controlled host, or a "docs" diff that quietly
+  touches code/config, is the oldest trick in the catalog (§G).

--- a/.claude/skills/review-external-pr/references/red-flags.md
+++ b/.claude/skills/review-external-pr/references/red-flags.md
@@ -1,0 +1,189 @@
+# Red-flag catalog — hunt the payload in the diff
+
+This is the adversarial sweep (SKILL.md §2, and re-used in §5). You are looking for the things a
+patient attacker hides in an otherwise-plausible PR, and for the careless mistakes that have the
+same blast radius because everything auto-updates to every user.
+
+**Grep the diff, not the tree** — you care about what this PR *adds*. Get it once and search added
+lines only:
+
+```bash
+gh pr diff <N> > /tmp/pr-<N>.diff
+added() { grep -nE '^\+[^+]' "/tmp/pr-<N>.diff" | grep -iE "$1"; }   # added lines matching a pattern
+```
+
+Every hit is a *lead*, not a verdict — open the file:line, read the surrounding code, and decide.
+But an un-investigated hit in a STOP category (SKILL.md) blocks the review.
+
+## Contents
+
+- [A. CI / workflow / repo-config tampering](#a) — the path to secrets and the signing key
+- [B. Dependency / supply-chain changes](#b)
+- [C. Network egress, exfiltration & code execution](#c)
+- [D. Obfuscation & trojan-source](#d)
+- [E. Generated-file & game-data poisoning](#e)
+- [F. Secrets & credentials](#f)
+- [G. Scope & honesty mismatch](#g)
+
+---
+
+<a id="a"></a>
+## A. CI / workflow / repo-config tampering — HIGHEST severity
+
+**Why.** A *fork* PR cannot read this repo's secrets on its own PR run — that's a deliberate
+boundary (CONTRIBUTING.md), so an attacker can't just print `TBH_SIGNING_PRIVATE_KEY` in a PR. The
+payoff comes **after merge**, when the workflow runs on `push`/`main` (or in the release build) with
+the `production` environment secrets — the Ed25519 signing key and `DISCORD_ANNOUNCE_WEBHOOK`. A
+poisoned action, a new exfil step, or a trigger that hands secrets to PR-controlled code is how you
+lose the signing key. **Any diff under `.github/` from an external contributor is a STOP → escalate**,
+full stop; the patterns below are what you point the maintainer at.
+
+```bash
+# Did the PR touch CI / actions / repo config at all?
+grep -nE '^\+\+\+ b/\.github/' /tmp/pr-<N>.diff
+grep -nE '^\+\+\+ b/(\.gitleaks\.toml|\.github/(workflows|actions|CODEOWNERS|dependabot))' /tmp/pr-<N>.diff
+```
+
+Point the maintainer at these specific patterns (each is a known CI-attack primitive):
+
+- **`pull_request_target` / `workflow_run`** — these run with a **read/write token and access to
+  secrets even for fork PRs**. Combined with checking out and building the PR head, this is the
+  classic "pwn request" that leaks secrets from an unmerged PR. `added 'pull_request_target|workflow_run'`
+- **Secret references added or moved** — `added 'secrets\.'` (esp. into a job a fork can trigger, or
+  echoed/curled anywhere).
+- **Permission escalation** — `added 'permissions:|contents: write|id-token: write|packages: write'`.
+- **Script injection** — untrusted `${{ github.event.* }}` (PR title/body/branch) interpolated into a
+  `run:` block. `added 'github\.event\.(pull_request|issue|comment)'` then read the `run:` around it.
+- **Un-pinned or repointed actions** — an action moved from a pinned SHA to a tag/branch, or to a
+  fork (`uses: someone-else/...`). This repo pins actions to SHAs on purpose — a change away from a
+  SHA is a supply-chain regression. `added 'uses:'`
+- **Arbitrary network / shell in build steps** — `added 'curl|wget|Invoke-WebRequest|nc |bash <|\| *sh'`.
+- **Self-hosted runners** — `added 'runs-on:.*self-hosted'`.
+- **The release/signing path itself** — any edit to `meter-build-core.yml`, `meter-2-build.yml`,
+  `meter-3-ship.yml`, `meter-1-stage.yml`, or `codeql.yml`/`scorecard.yml`/`secret-scan.yml`/
+  `dependency-review.yml` (weakening a security gate is as bad as adding an exploit).
+- **CODEOWNERS / branch-protection / gitleaks config** — a diff that removes reviewers, widens who
+  can approve, or loosens `.gitleaks.toml` is tampering with the controls, not the code.
+
+<a id="b"></a>
+## B. Dependency / supply-chain changes — STOP → escalate
+
+**Why.** A dependency runs with the app's full privileges and auto-ships to every user; a malicious
+or typosquatted package, or a `postinstall` hook, is the highest-leverage single-line attack. A
+"small feature" that *also* adds a dependency deserves 10× scrutiny on the dependency, not the
+feature. The dependency-review workflow helps, but a fork PR's checks may be held (§3) — verify by hand.
+
+```bash
+grep -nE '^\+\+\+ b/(app/package\.json|app/pnpm-lock\.yaml|reader/(requirements.*\.txt|pyproject\.toml)|release-video/package\.json)' /tmp/pr-<N>.diff
+added '"[^"]+": *"[^"]*"'          # added manifest entries (npm)
+added 'postinstall|preinstall|prepare|prepublish|install"'   # lifecycle scripts run code on install
+```
+
+- **The reader is zero-dependency by law** (pure `ctypes` + stdlib — CONTRIBUTING.md, `reader/CLAUDE.md`).
+  **Any** added entry in `reader/requirements.txt` / `pyproject.toml` is a giant flag; a runtime dep
+  there is almost never legitimate.
+- **Lifecycle scripts** (`postinstall` et al.) — code that runs the instant someone installs. Read it.
+- **Typosquat / dependency-confusion** — a package name that's a homoglyph or near-miss of a popular
+  one, or an internal-sounding name pulled from the public registry.
+- **Non-registry sources** — a git/URL/tarball/`file:` dependency, or `overrides`/`resolutions`
+  redirecting an existing dep to another version or source.
+- **Lockfile-only changes** — an integrity-hash or resolved-URL change in `pnpm-lock.yaml` with no
+  matching `package.json` change is lockfile poisoning. The lockfile must be explained by the manifest.
+- **Version bumps** — bumping an existing dep can pull a compromised release; treat a bump like a new
+  dep (what changed upstream, is the new version real and not yanked/backdoored).
+
+<a id="c"></a>
+## C. Network egress, exfiltration & code execution — STOP → escalate
+
+**Why.** The app already talks to exactly one place (`api.tbherohelper.com`, per SECURITY.md) and the
+reader talks to *nothing*. Any *new* outbound path or any dynamic code execution is how data (auth
+tokens, memory contents) leaves the machine or how attacker-controlled code runs.
+
+```bash
+added 'https?://|wss?://|fetch\(|XMLHttpRequest|WebSocket|dgram|net\.(connect|Socket)|dns\.'
+added 'child_process|execSync|execFile|spawn|\beval\(|new Function|require\([^'\''"]|import\('
+added 'socket|urllib|httplib|http\.client|requests|ftplib|smtplib|subprocess|os\.system|os\.popen|os\.exec|pty\.|pickle\.loads|marshal\.loads|__import__|getattr\('
+```
+
+- **App main process** — scrutinize any change to `API_URL`, `error-report.ts`, `share.ts`,
+  `auto-update.ts` (the update **feed URL** — repointing it hijacks auto-update), and
+  `request-signer.ts` (the Ed25519 signing). A new host, or user data flowing to a new sink, is exfil.
+- **Reader** — it is read-only and offline. Any `import socket/urllib/http/subprocess`, any
+  `os.system`/`popen`/`exec*`, or any `ctypes` process-manipulation beyond reading
+  (**`WriteProcessMemory`, `CreateRemoteThread`, `VirtualAllocEx`, `OpenProcess` with write/operation
+  access** — vs the allowed `PROCESS_VM_READ`) turns the sensor into an injector/cheat/malware.
+  See area-review.md → reader → memory-safety.
+- **Dynamic execution** — `eval`, `new Function`, dynamic `require`/`import`, Node `vm`/`child_process`,
+  Python `exec`/`eval`/`compile`/`pickle`/`marshal`/`__import__`/attribute-dispatch on attacker data.
+  A meter has essentially no legitimate reason to build and run code at runtime.
+- **Token/credential reads that then move** — reading the local auth token, env vars, or keytar and
+  passing it into any of the sinks above.
+
+<a id="d"></a>
+## D. Obfuscation & trojan-source — STOP → escalate
+
+**Why.** If you can't read it, you can't review it — and unreadable code is where payloads live.
+Trojan-source uses invisible or look-alike Unicode so the diff you *read* differs from what
+*compiles/runs*.
+
+```bash
+# Non-ASCII inside added lines (trojan-source / homoglyph identifiers). Excludes the legit
+# localization surface: i18n dicts, data JSON, and the known unicode test fixture (repo is
+# English-only by policy — non-ASCII anywhere ELSE in code is suspect).
+grep -nP '^\+[^+].*[^\x00-\x7F]' /tmp/pr-<N>.diff \
+  | grep -viE 'locales?/|i18n|/data/|\.json:|unicode.*fixture|test.*unicode'
+added 'atob|Buffer\.from\([^,]+, *.base64|fromCharCode|\\x[0-9a-f]{2}|\\u[0-9a-f]{4}|base64|b64decode|codecs\.decode'
+```
+
+- **Bidi / zero-width control chars** — U+202A–202E, U+2066–2069 (bidi overrides), U+200B–200D, U+FEFF
+  (zero-width). These reorder or hide code. The `grep -P` above surfaces any non-ASCII; inspect each.
+- **Homoglyph identifiers** — Cyrillic/Greek letters that look Latin, defining a second identifier that
+  shadows a real one.
+- **Encoded blobs** — long base64/hex strings, `atob`/`Buffer.from(...,'base64')`, `\xNN`/`\uNNNN`
+  arrays, minified or "vendored" bundles added as source. Decode and read them, or reject the blob.
+- **Whitespace tricks** — code pushed far off-screen to the right, or hidden after long comment lines.
+
+<a id="e"></a>
+## E. Generated-file & game-data poisoning — STOP → escalate
+
+**Why.** `app/src/shared/data/` and `app/src/renderer/public/{sprites,heroes}/` are **generated** from
+the `data/` snapshot by `scripts/sync-data.mjs` (hook-enforced) — they are not source. A diff that
+hand-edits them bypasses the pipeline and can inject arbitrary bundled content (code, or an image
+shipped to every user) while looking like a "data update." `data/` itself is the source snapshot, but
+it's regenerated from the wiki datamine (`scripts/refresh-game-data.mjs`), not authored by hand.
+
+```bash
+grep -nE '^\+\+\+ b/(app/src/shared/data/|app/src/renderer/public/(sprites|heroes)/)' /tmp/pr-<N>.diff
+grep -nE '^\+\+\+ b/data/' /tmp/pr-<N>.diff
+```
+
+- Any hunk touching the two generated paths → the contributor edited a build output. Reject and ask
+  them to change `data/` via the refresh script, and confirm the sync hook wasn't also disabled.
+- Edits to `data/`: are they a coherent datamine result, or arbitrary values? Binary sprite/asset
+  swaps can smuggle payloads or inappropriate images — verify provenance, don't eyeball a PNG.
+
+<a id="f"></a>
+## F. Secrets & credentials
+
+**Why.** No credentials live in this repo (SECURITY.md); gitleaks scans every PR. But a fork PR's
+scan may be held (§3), and gitleaks isn't perfect — verify, and note that weakening `.gitleaks.toml`
+(category A) is itself the attack.
+
+```bash
+added 'AKIA[0-9A-Z]{16}|ghp_[0-9A-Za-z]{36}|xox[baprs]-|-----BEGIN [A-Z ]*PRIVATE KEY|api[_-]?key|secret|token *[:=]'
+```
+
+Distinguish a real leaked credential (block, and warn: it must be rotated, not just deleted from the
+diff — git history keeps it) from a variable *named* `token` that holds nothing sensitive.
+
+<a id="g"></a>
+## G. Scope & honesty mismatch
+
+**Why.** The single most reliable tell across all of the above is a change that doesn't fit its story.
+Payloads ride in on unrelated hunks bundled into a plausible PR.
+
+- Cross-check the `files` list (§0) against the PR's stated purpose. A "fix typo" / "update docs" /
+  "bump copy" PR that touches `.github/`, `*.ts` in `src/main`, `reader/`, or any manifest is lying by
+  omission — treat the mismatch itself as the finding.
+- Every file outside the stated scope is a separate thing the contributor must justify. "While I was
+  here I also…" in security-sensitive code is where you slow down, not speed up.


### PR DESCRIPTION
## Description

Adds a dedicated, maintainer-run skill for reviewing pull requests from **external / untrusted contributors** (fork PRs, first-time or unknown authors). It is supply-chain defense, not ordinary code review: every merged PR auto-updates onto every user's machine and ships the memory-reading reader exe plus a signing-key-holding Electron app, so the skill treats the author and the PR description as untrusted and the diff as the only evidence. It runs an adversarial red-flag sweep, a per-area invariant check grounded in this repo's rules, and posts a **real GitHub review** with an inline comment pinned to each problematic line.

## Key changes

- `SKILL.md` — operating procedure: threat model, STOP conditions, and the pipeline (intake -> red-flag sweep -> CI-reality check -> area review -> isolated local verify -> post a formal `pulls/reviews` review with per-line inline comments). Distinct from `self-review`, which assumes a trusted author.
- `references/red-flags.md` — grep-able adversarial attack-surface catalog: workflow/CI tampering, dependency/supply-chain, network/exfiltration, code-exec, obfuscation/trojan-source, generated-file poisoning, secrets, scope abuse.
- `references/area-review.md` — per-area correctness checklists tied to the reader's read-only / obscured-data / offset invariants, the app main-process privilege boundary, and the renderer XSS + i18n guards.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [x] Refactor / chore / docs (no user-visible behavior change)

## How was this tested?

- [ ] `app/`: `pnpm check` and `pnpm test` pass — N/A, no `app/` change
- [ ] `reader/`: `ruff check .` and `pytest` pass — N/A, no `reader/` change
- [x] Dogfooded on a live fork PR (#90, "Add linux support"): fetched the diff, confirmed no memory-write/inject primitive, ran the sweeps, and posted a real `CHANGES_REQUESTED` review with 6 inline comments pinned to exact lines.

## Checklist

- [x] Conventional commit subjects — they drive the computed release version and the changelog
- [x] Self-reviewed the diff
- [x] No hand-edits to generated/synced files
- [x] No secrets committed

---
Note: this PR touches only `.claude/` (no `app/` / `reader/` / `data/`), so the app/reader/CodeQL CI jobs are path-filtered and will not report — it will need an admin merge.