### PR TITLE
fix: prevent overlay width changes while dragging

### DIFF
--- a/app/src/main/__tests__/live-drag.test.ts
+++ b/app/src/main/__tests__/live-drag.test.ts
@@ -11,12 +11,12 @@ import { createLiveDrag, type LiveDragDeps, type Point } from "../live-drag.js";
 
 function harness(opts: { bounds: { x: number; y: number; width: number; height: number } }) {
   let cursor: Point = { x: 0, y: 0 };
-  const setPosition = vi.fn();
+  const setBounds = vi.fn();
   const setWidth = vi.fn();
   const win = {
     isDestroyed: () => false,
     getBounds: () => opts.bounds,
-    setPosition,
+    setBounds,
   } as unknown as BrowserWindow;
   const deps: LiveDragDeps = {
     getWindow: () => win,
@@ -28,7 +28,7 @@ function harness(opts: { bounds: { x: number; y: number; width: number; height: 
     setCursor: (p: Point) => {
       cursor = p;
     },
-    setPosition,
+    setBounds,
     setWidth,
   };
 }
@@ -62,7 +62,21 @@ describe("createLiveDrag — move (position)", () => {
     h.setCursor({ x: 400.6, y: 250.4 });
     h.drag.move();
     // new top-left = cursor − grab offset = (400.6 − 50, 250.4 − 20) rounded
-    expect(h.setPosition).toHaveBeenCalledWith(351, 230);
+    expect(h.setBounds).toHaveBeenCalledWith({ x: 351, y: 230, width: 420, height: 48 });
+  });
+
+  it("keeps the pointer-down size when Windows reports mutated bounds mid-drag", () => {
+    const bounds = { x: 100, y: 50, width: 435, height: 92 };
+    const h = harness({ bounds });
+    h.setCursor({ x: 150, y: 70 });
+    h.drag.start("move");
+
+    bounds.x = 90;
+    bounds.width = 600;
+    h.setCursor({ x: 250, y: 170 });
+    h.drag.move();
+
+    expect(h.setBounds).toHaveBeenCalledWith({ x: 200, y: 150, width: 435, height: 92 });
   });
 });
 
@@ -76,7 +90,7 @@ describe("createLiveDrag — lifecycle", () => {
     h.setCursor({ x: 900, y: 10 });
     h.drag.move(); // ended
     expect(h.setWidth).not.toHaveBeenCalled();
-    expect(h.setPosition).not.toHaveBeenCalled();
+    expect(h.setBounds).not.toHaveBeenCalled();
   });
 
   it("is a no-op when the live window is gone", () => {

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -94,7 +94,7 @@ let quitting = false;
 // True only while the user is MOVING the overlay (title-bar drag). A pure reposition can't
 // change the content height, so any pinLiveHeight / bounds-save that fires mid-move is
 // spurious — it's a transient repaint from the OS move on high-DPI, and calling setBounds
-// (or persisting getBounds().width) mid-setPosition re-enters Windows' DIP scaling and
+// (or persisting getBounds().width) during a move re-enters Windows' DIP scaling and
 // drives the width/position drift this bug is made of (#live-drag-width-feedback). We freeze
 // the window geometry for the duration of the move and settle once on release.
 let liveMoveActive = false;
@@ -190,12 +190,14 @@ function createLiveWindow(): BrowserWindow {
   });
 
   win.on("moved", () => {
-    // Mid our custom MOVE drag the window is being setPosition'd; getBounds().width can read
+    // During our custom MOVE drag, getBounds().width can read
     // transiently inflated on high-DPI, so saving here would persist a bad width that the
     // next launch reopens at. endWindowDrag saves once on release with stable bounds.
     if (!liveMoveActive) saveLiveBounds(win);
   });
-  win.on("resized", () => saveLiveBounds(win));
+  win.on("resized", () => {
+    if (!liveMoveActive) saveLiveBounds(win);
+  });
 
   // close -> hide instead of destroy, unless the app is genuinely quitting.
   win.on("close", (event) => {
@@ -368,7 +370,7 @@ let liveContentHeight = 48;
 
 // The last known-good width, in DIP. Stored separately from the live window's bounds
 // because getBounds().width can return transient inflated values on Windows while a
-// transparent frameless window is being dragged via setPosition() on high-DPI monitors
+// transparent frameless window is being dragged on high-DPI monitors
 // (200 % / 4K). When pinLiveHeight fires mid-drag and re-applies that transient width
 // via setBounds, it creates a feedback loop that drives the width upward every tick of
 // the move — the overlay keeps growing while the user drags (#live-drag-width-feedback).
@@ -383,8 +385,8 @@ let lastKnownWidth = DEFAULT_LIVE_WIDTH;
  *  feedback loop during a move drag on high-DPI monitors (see lastKnownWidth). */
 function pinLiveHeight(): void {
   if (!liveWin || liveWin.isDestroyed()) return;
-  // Never resize the overlay mid-MOVE — see liveMoveActive. The drag's setPosition is the
-  // only thing that may touch the window; a setBounds here fights it and, on high-DPI,
+  // Never resize the overlay mid-MOVE — see liveMoveActive. The drag's atomic fixed-size bounds
+  // are the only geometry writes allowed here; a second setBounds can fight them and, on high-DPI,
   // re-inflates the width. Content height can't change during a pure move, so nothing is
   // lost; endWindowDrag re-pins once to settle.
   if (liveMoveActive) return;
@@ -527,7 +529,7 @@ app.whenReady().then(() => runIfPrimary(isPrimaryInstance, async () => {
       liveDrag.end();
       if (!liveMoveActive) return; // resize / idle: per-tick saves already persisted
       liveMoveActive = false;
-      pinLiveHeight(); // settle: re-pin with a now-stable getBounds (setPosition stopped)
+      pinLiveHeight(); // settle: re-pin with a now-stable getBounds (drag writes stopped)
       if (liveWin && !liveWin.isDestroyed()) saveLiveBounds(liveWin);
     },
     resetLiveWindow,

--- a/app/src/main/live-drag.ts
+++ b/app/src/main/live-drag.ts
@@ -20,6 +20,9 @@ interface DragState {
   /** The window's left/top at grab (DIP). For resize, winX is the fixed left edge. */
   winX: number;
   winY: number;
+  /** Freeze the move size at grab so Windows cannot apply a transient edge resize. */
+  width: number;
+  height: number;
   /** Cursor offset within the window at grab (DIP) — keeps the grab point under the cursor while moving. */
   offX: number;
   offY: number;
@@ -51,7 +54,15 @@ export function createLiveDrag(deps: LiveDragDeps): {
       if (!win) return;
       const b = win.getBounds();
       const c = deps.getCursor();
-      state = { mode, winX: b.x, winY: b.y, offX: c.x - b.x, offY: c.y - b.y };
+      state = {
+        mode,
+        winX: b.x,
+        winY: b.y,
+        width: b.width,
+        height: b.height,
+        offX: c.x - b.x,
+        offY: c.y - b.y,
+      };
     },
 
     move(): void {
@@ -62,7 +73,12 @@ export function createLiveDrag(deps: LiveDragDeps): {
         // Left edge fixed (setWidth keeps b.x); width = cursor − left edge.
         deps.setWidth(c.x - state.winX);
       } else {
-        win.setPosition(Math.round(c.x - state.offX), Math.round(c.y - state.offY));
+        win.setBounds({
+          x: Math.round(c.x - state.offX),
+          y: Math.round(c.y - state.offY),
+          width: state.width,
+          height: state.height,
+        });
       }
     },
 


### PR DESCRIPTION
## Description

Keep the live overlay's width and height fixed throughout a native drag on Windows 11. The drag loop previously reused mutable window bounds, so a transient widened renderer bound could be reapplied on every mouse move until the button was released.

## Key changes

- Capture immutable width and height at drag start and include them in every `setBounds` update.
- Suppress move/resize persistence callbacks while the native live drag is active.
- Add a regression test that injects a widened bound during drag and verifies the original width is retained.

## Screenshots

Not applicable as a still image: the defect only appeared while the mouse button was held. Manually verified on Windows 11 with the portable `rc.7` build; the overlay remains the same width through click, hold, movement, and release.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would break existing behavior)
- [ ] Refactor / chore / docs (no user-visible behavior change)

## How was this tested?

- [x] `app/`: `pnpm check` and `pnpm test` pass
- [ ] `reader/`: `ruff check .` and `pytest` pass
- [x] Manually verified in the running app (Windows for the reader path; macOS dev renders the UI only)

Exact results:

- `pnpm check`: passed
- `pnpm test`: 58 files, 837 tests passed
- Reader checks were not run for this branch because it changes only `app/` files.
- Windows 11 live test: repeated click-hold-drag-release cycles kept the overlay width fixed; no left-side horizontal expansion occurred.

## Checklist

- [x] Conventional commit subjects - they drive the computed release version and the changelog
- [x] Self-reviewed the diff
- [x] No hand-edits to generated/synced files (`app/src/shared/data/`, `app/src/renderer/public/{sprites,heroes}/`) - edit the `data/` snapshot via `scripts/refresh-game-data.mjs` instead
- [x] No secrets committed
